### PR TITLE
Better metric name for static_collector_kubernetes_discovered_pods

### DIFF
--- a/engine/kubernetes_discovery.rb
+++ b/engine/kubernetes_discovery.rb
@@ -223,6 +223,7 @@ class KubernetesDiscovery
       'sources' => {
         'kubernetes_discovery_static_metrics' => {
           'type' => 'static_metrics',
+          'namespace' => '',  # Empty namespace to avoid "static_" prefix
           'metrics' => [
             {
               'name' => 'collector_kubernetes_discovered_pods',

--- a/engine/vector_config.rb
+++ b/engine/vector_config.rb
@@ -10,6 +10,7 @@ class VectorConfig
     sources:
       kubernetes_discovery_static_metrics:
         type: static_metrics
+        namespace: ''  # Empty namespace to avoid "static_" prefix
         metrics:
           - name: collector_kubernetes_discovered_pods
             kind: absolute

--- a/kubernetes-discovery/0-default/discovered_pods.yaml
+++ b/kubernetes-discovery/0-default/discovered_pods.yaml
@@ -2,6 +2,7 @@
 sources:
   kubernetes_discovery_static_metrics:
     type: static_metrics
+    namespace: ''  # Empty namespace to avoid "static_" prefix
     metrics:
       - name: collector_kubernetes_discovered_pods
         kind: absolute


### PR DESCRIPTION
Better name for metric telling you the number of discovered pods:
static_collector_kubernetes_discovered_pods -> collector_kubernetes_discovered_pods