### PR TITLE
T-8598: Add coroot-node-agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.11
+ENV COLLECTOR_VERSION=1.0.12
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/Dockerfile.beyla
+++ b/Dockerfile.beyla
@@ -1,3 +1,6 @@
+# Add Node Agent to the image
+FROM ghcr.io/coroot/coroot-node-agent:1.25.0 AS node-agent
+
 # Build dockerprobe
 FROM golang:1.24.4-alpine3.22 AS dockerprobe-builder
 WORKDIR /src
@@ -9,11 +12,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags='-s -w' -o /bin/dockerprobe .
 # Get Beyla files from official image
 FROM grafana/beyla:2.2.4 AS beyla-source
 
-# Final stage - Alpine based
-FROM alpine:3.22
+# Final stage - Using Debian for glibc compatibility with node-agent
+FROM debian:12-slim
 
 # Install supervisor and ca-certificates
-RUN apk add --no-cache supervisor ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends supervisor ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create necessary directories
 RUN mkdir -p /etc/supervisor/conf.d /var/log/supervisor /enrichment
@@ -23,6 +29,9 @@ COPY --from=beyla-source --chmod=755 /beyla /usr/local/bin/beyla
 COPY --from=beyla-source /LICENSE /LICENSE
 COPY --from=beyla-source /NOTICE /NOTICE
 COPY --from=beyla-source /third_party_licenses.csv /third_party_licenses.csv
+
+# Copy Node Agent
+COPY --from=node-agent --chmod=755 /usr/bin/coroot-node-agent /usr/local/bin/node-agent
 
 # Copy dockerprobe binary with permissions
 COPY --from=dockerprobe-builder --chmod=755 /bin/dockerprobe /usr/local/bin/dockerprobe

--- a/beyla/supervisord.conf
+++ b/beyla/supervisord.conf
@@ -11,6 +11,16 @@ stdout_logfile=/var/log/supervisor/beyla.out.log
 stderr_logfile=/var/log/supervisor/beyla.err.log
 environment=PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
+# Runs the Coroot Node Agent to collect metrics from the cluster, shipping them to Vector
+# via the proxy in the collector container.
+[program:node-agent]
+command=/usr/local/bin/node-agent --collector-endpoint http://localhost:33000 --scrape-interval=15s
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/supervisor/node-agent.out.log
+stderr_logfile=/var/log/supervisor/node-agent.err.log
+environment=PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # Runs the `dockerprobe` binary to produce a CSV file associating process IDs to container IDs and names.
 # This CSV file is shared from the Beyla container to the Collector container via the docker-metadata volume mounted at /enrichment.
 # Sources for the `dockerprobe` binary are located in the `dockerprobe` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       - docker-metadata:/enrichment:rw
     ports:
       # Bind to localhost only for security - Beyla will connect via host network
-      - "127.0.0.1:34320:34320"
+      - "127.0.0.1:34320:34320" # Beyla metrics endpoint
+      - "127.0.0.1:33000:33000" # Vector proxy endpoint
 
   beyla:
     build:


### PR DESCRIPTION
* integrate coroot-node-agent into the Beyla container
* Alpine is no longer viable - node agent is dynamically linked and _really_ doesn't like musl
* explored using the minimal RHEL-based image node agent is using as a base, but installing supervisord would involve messing with EPEL, and it's only smaller by ~10MB than debian slim