### PR TITLE
T-8953: prefer reporting $HOSTNAME in ping if available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,25 @@ jobs:
 
     - name: Validate Docker compose build
       run: docker compose build --no-cache
+
+  # The diff is expected to be:
+  # 8a9,10
+  # >     security_opt:
+  # >       - seccomp=collector-seccomp.json
+  # if there are more lines, it's likely drift and shouldn't be released
+  docker-compose-match:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: check diff between docker-compose.yml and docker-compose.seccomp.yml
+      run: |
+        DIFF_LINES=$(diff docker-compose.yml docker-compose.seccomp.yml | wc -l)
+        if [ "$DIFF_LINES" -ne 3 ]; then
+          echo "ERROR: Expected exactly 3 lines of diff, but got $DIFF_LINES lines"
+          echo "Diff output:"
+          diff docker-compose.yml docker-compose.seccomp.yml
+          exit 1
+        fi
+        echo "✓ Diff is exactly 3 lines as expected" 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.13
+ENV COLLECTOR_VERSION=1.0.14
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.12
+ENV COLLECTOR_VERSION=1.0.13
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -62,7 +62,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
-      - docker-metadata:/enrichment:ro
+      - docker-metadata:/enrichment:rw
     depends_on:
       - collector
 

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -25,10 +25,11 @@ services:
       - /var/lib/docker/containers:/host/var/lib/docker/containers:ro
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
-      - docker-metadata:/enrichment:ro
+      - docker-metadata:/enrichment:rw
     ports:
       # Bind to localhost only for security - Beyla will connect via host network
-      - "127.0.0.1:34320:34320"
+      - "127.0.0.1:34320:34320" # Beyla metrics endpoint
+      - "127.0.0.1:33000:33000" # Vector proxy endpoint
 
   beyla:
     build:
@@ -67,5 +68,3 @@ services:
 
 volumes:
   docker-metadata:
-
-

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -62,7 +62,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
-      - docker-metadata:/enrichment:rw
+      - docker-metadata:/enrichment:ro
     depends_on:
       - collector
 

--- a/engine/utils.rb
+++ b/engine/utils.rb
@@ -80,6 +80,8 @@ module Utils
   end
 
   def hostname
+    return ENV['HOSTNAME'] if ENV['HOSTNAME']
+
     # Try to get hostname from kubernetes mounted hostPath, if available
     if File.exist?('/host/proc/sys/kernel/hostname')
       return File.read('/host/proc/sys/kernel/hostname').strip

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -170,6 +170,10 @@ class UtilsTest < Minitest::Test
   end
 
   def test_hostname
+    # Pretend hostname is not available to test other fallback mechanisms
+    original_hostname = ENV['HOSTNAME']
+    ENV['HOSTNAME'] = nil
+
     # Test fallback to Socket.gethostname when host files not available
     # Mock Socket.gethostname to return a known value
     original_method = Socket.method(:gethostname)
@@ -212,6 +216,13 @@ class UtilsTest < Minitest::Test
     # Restore original methods
     File.define_singleton_method(:exist?, original_exist)
     File.define_singleton_method(:read, original_read)
+
+    # Despite all the previous setup, if HOSTNAME is set, it should be used
+    ENV['HOSTNAME'] = 'host-from-env'
+    assert_equal "host-from-env", hostname
+
+    # Restore original env var
+    ENV['HOSTNAME'] = original_hostname
   end
 
 end


### PR DESCRIPTION
also fixes drift in seccomp compose file, and adds a GitHub action to keep that in check. it's too easy to miss, and "I'll remember to do it" is not a strategy.