### PR TITLE
Resolve volume mount conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,13 @@ RUN mkdir -p /versions/0-default \
   && mkdir -p /var/lib/vector \
   && mkdir -p /var/log/supervisor \
   && mkdir -p /kubernetes-discovery/0-default \
-  && mkdir -p /vector-config
+  && mkdir -p /vector-config \
+  && mkdir -p /enrichment-defaults
 
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.15
+ENV COLLECTOR_VERSION=1.0.16
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4
@@ -78,6 +79,11 @@ COPY engine /engine
 COPY should_run_cluster_collector.rb /should_run_cluster_collector.rb
 COPY --chmod=755 cluster-collector.sh /cluster-collector.sh
 COPY --chmod=755 ebpf.sh /ebpf.sh
+# Copy default enrichment files to both locations
+# /enrichment-defaults is the source for copying at runtime
+# /enrichment is for backwards compatibility when not using volumes
+COPY dockerprobe/docker-mappings.default.csv /enrichment-defaults/docker-mappings.csv
+COPY dockerprobe/databases.default.csv /enrichment-defaults/databases.csv
 COPY dockerprobe/docker-mappings.default.csv /enrichment/docker-mappings.csv
 COPY dockerprobe/databases.default.csv /enrichment/databases.csv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ COPY --chmod=755 cluster-collector.sh /cluster-collector.sh
 COPY --chmod=755 ebpf.sh /ebpf.sh
 # Copy default enrichment files to both locations
 # /enrichment-defaults is the source for copying at runtime
-# /enrichment is for backwards compatibility when not using volumes
+# /enrichment is for Kubernetes compatibility, since it's volume mounts work differently from compose/swarm
 COPY dockerprobe/docker-mappings.default.csv /enrichment-defaults/docker-mappings.csv
 COPY dockerprobe/databases.default.csv /enrichment-defaults/databases.csv
 COPY dockerprobe/docker-mappings.default.csv /enrichment/docker-mappings.csv

--- a/engine/better_stack_client.rb
+++ b/engine/better_stack_client.rb
@@ -253,13 +253,7 @@ class BetterStackClient
 
       puts "All files downloaded. Validating configuration..."
 
-      # Validate vector config
       version_dir = File.join(@working_dir, "versions", new_version)
-      validate_output = @vector_config.validate_upstream_files(version_dir)
-      unless validate_output.nil?
-        write_error("Validation failed for vector config in #{new_version}\n\n#{validate_output}")
-        return
-      end
 
       # Validate databases.csv if it exists in this version
       if databases_csv_exists
@@ -280,6 +274,14 @@ class BetterStackClient
           return
         end
       end
+
+      # Validate vector config
+      validate_output = @vector_config.validate_upstream_files(version_dir)
+      unless validate_output.nil?
+        write_error("Validation failed for vector config in #{new_version}\n\n#{validate_output}")
+        return
+      end
+
 
       # All validations passed, now promote everything
       @vector_config.promote_upstream_files(version_dir)

--- a/vector.sh
+++ b/vector.sh
@@ -17,10 +17,21 @@ echo "  AZ=${AZ}"
 export PROCFS_ROOT="/host/proc"
 export SYSFS_ROOT="/host/sys"
 
-# Ensure enrichment directory exists with dummy CSV if needed
+# Ensure enrichment directory exists
 if [ ! -d "/enrichment" ]; then
     echo "Creating /enrichment directory..."
     mkdir -p /enrichment
+fi
+
+# Copy default enrichment files if they don't exist
+if [ ! -f "/enrichment/databases.csv" ] && [ -f "/enrichment-defaults/databases.csv" ]; then
+    echo "Copying default databases.csv to /enrichment..."
+    cp /enrichment-defaults/databases.csv /enrichment/databases.csv
+fi
+
+if [ ! -f "/enrichment/docker-mappings.csv" ] && [ -f "/enrichment-defaults/docker-mappings.csv" ]; then
+    echo "Copying default docker-mappings.csv to /enrichment..."
+    cp /enrichment-defaults/docker-mappings.csv /enrichment/docker-mappings.csv
 fi
 
 echo "Starting Vector..."


### PR DESCRIPTION
Because the volume is mounted from two containers, the contents may be overwritten.
In my testing it's intermittent, but leads to a failure in starting via compose when it does.
This way we ensure that no matter what happens, the defaults file _or_ target file is in place
for either enrichment table before vector attempts to boot.