### PR TITLE
T-9053: adjust `clone3` seccomp profile

### DIFF
--- a/collector-seccomp.json
+++ b/collector-seccomp.json
@@ -674,21 +674,6 @@
 		},
 		{
 			"names": [
-				"clone3"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"errnoRet": 38,
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			}
-		},
-		{
-			"names": [
 				"reboot"
 			],
 			"action": "SCMP_ACT_ALLOW",


### PR DESCRIPTION
There was a mistake in the profile - the `clone3` action was explicitly disallowed, except under `CAP_SYS_ADMIN`. This is generally a reasonable protection, except in cases where we tightly control the workload, like in the collector's case.

This patch removes the explicit block, which should allow the `clone3` calls we need.