### PR TITLE
T-9202: Include OTel instrumented services in Beyla

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.20
+ENV COLLECTOR_VERSION=1.0.21
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/beyla.yaml
+++ b/beyla.yaml
@@ -5,6 +5,8 @@ discovery:
   exclude_services:
     - exe_path: ".*/vector$"
 
+  exclude_otel_instrumented_services: false
+
 otel_metrics_export:
   features:
     - application


### PR DESCRIPTION
By default, Beyla excludes processes already instrumented with OTel
SDKs: https://grafana.com/docs/beyla/latest/configure/service-discovery/#exclude-otel-instrumented-services

We don't want this behavior - leads to oddities like suddenly stopping traces.