### PR TITLE
Only clear error on successful configuration update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.21
+ENV COLLECTOR_VERSION=1.0.22
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/engine/better_stack_client.rb
+++ b/engine/better_stack_client.rb
@@ -156,7 +156,6 @@ class BetterStackClient
     case code
     when '204'
       puts "No updates available"
-      clear_error
       return
     when '200'
       data = JSON.parse(body)
@@ -168,7 +167,6 @@ class BetterStackClient
       else
         # Status is not 'new_version_available', could be an error message or other status
         puts "No new version. Status: #{data['status']}"
-        clear_error
         return
       end
     when '401', '403'

--- a/test/better_stack_client_ping_test.rb
+++ b/test/better_stack_client_ping_test.rb
@@ -182,7 +182,7 @@ class BetterStackClientPingTest < Minitest::Test
     assert error_content.include?("Validation failed for vector config with kubernetes_discovery")
   end
 
-  def test_ping_clears_error_file_when_no_updates
+  def test_ping_does_not_clear_error_file_when_no_updates
     # Create an error file
     File.write(File.join(@test_dir, 'errors.txt'), "Previous error")
 
@@ -195,8 +195,8 @@ class BetterStackClientPingTest < Minitest::Test
 
     @client.ping
 
-    # Test actual behavior - should clear error file when no updates
+    # Test actual behavior - should NOT clear error file when no updates
     assert_requested(stub, times: 1)
-    assert !File.exist?(File.join(@test_dir, 'errors.txt')), "Error file should be cleared"
+    assert File.exist?(File.join(@test_dir, 'errors.txt')), "Error file should not be cleared"
   end
 end


### PR DESCRIPTION
When the configuration wasn't updated, it's highly likely it's still invalid in some way. Vector will continue working with the previous version, but `ping` should continue returning an error until a valid configuration is supplied.