### PR TITLE
FIX: boot-loop in collector

### DIFF
--- a/certbot-runner.sh
+++ b/certbot-runner.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 TLS_DOMAIN="${TLS_DOMAIN:-}"
 
 if [[ -z "$TLS_DOMAIN" ]]; then
-  echo "[certbot] TLS_DOMAIN not set; certbot supervisor program will not run."
-  exit 0
+  echo "[certbot] TLS_DOMAIN not set; sleeping indefinitely."
+  exec sleep infinity
 fi
 
 CERT_LIVE_DIR="/etc/letsencrypt/live/${TLS_DOMAIN}"


### PR DESCRIPTION
Exiting with code 0 causes supervisor to restart the process. After several restarts, supervisor decides the start failed and the container restarts. Repeats forever. 🙈