### PR TITLE
help Beyla container stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.25
+ENV COLLECTOR_VERSION=1.0.26
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -41,6 +41,9 @@ services:
     image: betterstack/collector-beyla:latest
     container_name: better-stack-beyla
     restart: always
+    init: true
+    stop_signal: SIGTERM
+    stop_grace_period: 90s
     privileged: true
     pid: host
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
     image: betterstack/collector-beyla:latest
     container_name: better-stack-beyla
     restart: always
+    init: true
+    stop_signal: SIGTERM
+    stop_grace_period: 90s
     privileged: true
     pid: host
     network_mode: host

--- a/dockerprobe/go.mod
+++ b/dockerprobe/go.mod
@@ -2,7 +2,10 @@ module dockerprobe
 
 go 1.24.4
 
-require github.com/docker/docker v27.5.0+incompatible
+require (
+	github.com/docker/docker v27.5.0+incompatible
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+)
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/dockerprobe/go.sum
+++ b/dockerprobe/go.sum
@@ -84,6 +84,7 @@ golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
 golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
- `init: true` for easier zombie reaping
- longer grace period - Beyla genuinely takes 30s+ to unhook ebpf sometimes
- improvements to dockerprobe - better recognition/handling of stop signals (pausing and exiting ASAP, not about ~once per interval)