### PR TITLE
Beyla memory management issues

### DIFF
--- a/Dockerfile.beyla
+++ b/Dockerfile.beyla
@@ -20,7 +20,7 @@ FROM debian:12-slim
 
 # Install supervisor, ca-certificates, and curl
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends supervisor ca-certificates curl && \
+    apt-get install -y --no-install-recommends supervisor ca-certificates curl procps && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.beyla
+++ b/Dockerfile.beyla
@@ -13,7 +13,7 @@ COPY dockerprobe/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags='-s -w' -o /bin/dockerprobe .
 
 # Get Beyla files from official image
-FROM grafana/beyla:2.2.4 AS beyla-source
+FROM grafana/beyla:2.5.8 AS beyla-source
 
 # Final stage - Using Debian for glibc compatibility with node-agent
 FROM debian:12-slim

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -48,9 +48,21 @@ services:
     pid: host
     network_mode: host
     mem_limit: 1536m
+    healthcheck:
+      test: |
+        MEM_USAGE=$$(cat /proc/1/status | grep VmRSS | awk '{print int($$2/1024)}') && \
+        THRESHOLD=1450 && \
+        if [ "$$MEM_USAGE" -gt "$$THRESHOLD" ]; then \
+          echo "Memory usage $${MEM_USAGE}MiB exceeds threshold $${THRESHOLD}MiB"; \
+          exit 1; \
+        fi
+      interval: 30s
+      timeout: 5s
+      start_period: 60s
+      retries: 2
     environment:
       # Set Go memory limit to slightly less than container limit
-      - GOMEMLIMIT=1450MiB
+      - GOMEMLIMIT=1400MiB
       # Pass hostname of host machine to Beyla; needs `export HOSTNAME` before running `docker compose up`
       - HOSTNAME
       # Override OTLP endpoint to point to collector container

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -47,6 +47,7 @@ services:
     privileged: true
     pid: host
     network_mode: host
+    mem_limit: 1536m
     environment:
       # Pass hostname of host machine to Beyla; needs `export HOSTNAME` before running `docker compose up`
       - HOSTNAME

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -50,10 +50,15 @@ services:
     mem_limit: 1536m
     healthcheck:
       test: |
-        MEM_USAGE=$$(cat /proc/1/status | grep VmRSS | awk '{print int($$2/1024)}') && \
+        BEYLA_PID=$$(pgrep -f '^/usr/local/bin/beyla' | head -1) && \
+        if [ -z "$$BEYLA_PID" ]; then \
+          echo "Beyla process not found"; \
+          exit 1; \
+        fi && \
+        MEM_USAGE=$$(cat /proc/$$BEYLA_PID/status | grep VmRSS | awk '{print int($$2/1024)}') && \
         THRESHOLD=1450 && \
         if [ "$$MEM_USAGE" -gt "$$THRESHOLD" ]; then \
-          echo "Memory usage $${MEM_USAGE}MiB exceeds threshold $${THRESHOLD}MiB"; \
+          echo "Beyla memory usage $${MEM_USAGE}MiB exceeds threshold $${THRESHOLD}MiB"; \
           exit 1; \
         fi
       interval: 30s

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -49,6 +49,8 @@ services:
     network_mode: host
     mem_limit: 1536m
     environment:
+      # Set Go memory limit to slightly less than container limit
+      - GOMEMLIMIT=1450MiB
       # Pass hostname of host machine to Beyla; needs `export HOSTNAME` before running `docker compose up`
       - HOSTNAME
       # Override OTLP endpoint to point to collector container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         MEM_USAGE=$$(cat /proc/1/status | grep VmRSS | awk '{print int($$2/1024)}') && \
         THRESHOLD=1450 && \
         if [ "$$MEM_USAGE" -gt "$$THRESHOLD" ]; then \
-          echo "Memory usage $${E}MiB exceeds threshold $${THRESHOLD}MiB"; \
+          echo "Memory usage $${MEM_USAGE}MiB exceeds threshold $${THRESHOLD}MiB"; \
           exit 1; \
         fi
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,10 +48,15 @@ services:
     mem_limit: 1536m
     healthcheck:
       test: |
-        MEM_USAGE=$$(cat /proc/1/status | grep VmRSS | awk '{print int($$2/1024)}') && \
+        BEYLA_PID=$$(pgrep -f '^/usr/local/bin/beyla' | head -1) && \
+        if [ -z "$$BEYLA_PID" ]; then \
+          echo "Beyla process not found"; \
+          exit 1; \
+        fi && \
+        MEM_USAGE=$$(cat /proc/$$BEYLA_PID/status | grep VmRSS | awk '{print int($$2/1024)}') && \
         THRESHOLD=1450 && \
         if [ "$$MEM_USAGE" -gt "$$THRESHOLD" ]; then \
-          echo "Memory usage $${MEM_USAGE}MiB exceeds threshold $${THRESHOLD}MiB"; \
+          echo "Beyla memory usage $${MEM_USAGE}MiB exceeds threshold $${THRESHOLD}MiB"; \
           exit 1; \
         fi
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     privileged: true
     pid: host
     network_mode: host
+    mem_limit: 1536m
     environment:
       # Pass hostname of host machine to Beyla; needs `export HOSTNAME` before running `docker compose up`
       - HOSTNAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     network_mode: host
     mem_limit: 1536m
     environment:
+      # Set Go memory limit to slightly less than container limit
+      - GOMEMLIMIT=1450MiB
       # Pass hostname of host machine to Beyla; needs `export HOSTNAME` before running `docker compose up`
       - HOSTNAME
       # Override OTLP endpoint to point to collector container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,21 @@ services:
     pid: host
     network_mode: host
     mem_limit: 1536m
+    healthcheck:
+      test: |
+        MEM_USAGE=$$(cat /proc/1/status | grep VmRSS | awk '{print int($$2/1024)}') && \
+        THRESHOLD=1450 && \
+        if [ "$$MEM_USAGE" -gt "$$THRESHOLD" ]; then \
+          echo "Memory usage $${E}MiB exceeds threshold $${THRESHOLD}MiB"; \
+          exit 1; \
+        fi
+      interval: 30s
+      timeout: 5s
+      start_period: 60s
+      retries: 2
     environment:
       # Set Go memory limit to slightly less than container limit
-      - GOMEMLIMIT=1450MiB
+      - GOMEMLIMIT=1400MiB
       # Pass hostname of host machine to Beyla; needs `export HOSTNAME` before running `docker compose up`
       - HOSTNAME
       # Override OTLP endpoint to point to collector container


### PR DESCRIPTION
- Beyla 2.5.x branch includes `Memory optimisations and other small bug fixes related to crashes` from OBI [release notes](https://github.com/grafana/beyla/releases/tag/v2.5.4)
- there's more promising items incoming from OBI:
	- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/562
	- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/545
	- these are either not backported yet to the [Beyla fork of OBI](https://github.com/grafana/opentelemetry-ebpf-instrumentation/tree/e184c6f7beb466b0e58a84d3ecb114d06053f490), or not pulled into 2.5
	- memory will likely benefit further from adopting the [2.6 branch](https://github.com/grafana/beyla/releases/tag/v2.6.0) too, once it's out of pre-release status
- there are suggestions that Beyla benefits greatly from setting `GOMEMLIMIT`, especially in task-dense environments: https://github.com/grafana/beyla/issues/1354

This also addresses #40 via setting up an onion of memory limits:

- `mem_limit` to 1536MiB, in line with the Helm chart
- a healthcheck to restart the container cleanly if it goes above 1450 MiB for >1 minute
	- we ideally want a clean restart rather than an OOMkill so Beyla can flush buffers
- setting `GOMEMLIMIT` to 1450MiB, targetting the garbage collector to aim for just short of the healthcheck limit
	- this will cause more aggressive garbage collection cycles
	- targeting `heap_goal = min(GOGC-based-goal, GOMEMLIMIT - nonheap_estimate)`
	- the beyla binary is statically linked, meaning there shouldn't be cgo in the picture to inflate `nonheap_estimate`
- `GOMEMLIMIT` will also technically affect `dockerprobe`, but we intend to replace it anyway and it consumes ~15MiB of memory at the moment; it should be pretty clean in terms of allocations

I will also backport these environment variable changes to the helm chart momentarily.