### PR TITLE
update to beyla 2.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.27
+ENV COLLECTOR_VERSION=1.0.28
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/Dockerfile.beyla
+++ b/Dockerfile.beyla
@@ -13,7 +13,7 @@ COPY dockerprobe/main.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags='-s -w' -o /bin/dockerprobe .
 
 # Get Beyla files from official image
-FROM grafana/beyla:2.5.8 AS beyla-source
+FROM grafana/beyla:2.6.1 AS beyla-source
 
 # Final stage - Using Debian for glibc compatibility with node-agent
 FROM debian:12-slim


### PR DESCRIPTION
beyla 2.5.8 appears to introduce a crash bug that shows up on at least `6.8.0-71-generic` after running for ~15 minutes.

this doesn't appear to occur in 2.6.1. it is marked pre-release, but the memory characteristics of this branch also seem better than 2.5.x in testing.