### PR TITLE
Remote proxy domain management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,40 +105,45 @@ Logs available in `/var/log/supervisor/*` in each container
 - `BASE_URL` - API endpoint (default: https://telemetry.betterstack.com)
 - `CLUSTER_COLLECTOR` - Force cluster collector mode
 - `INGESTING_HOST`, `SOURCE_TOKEN` - Required for test server
-- `TLS_DOMAIN` (optional) - Fully-qualified domain name for TLS certificate management
-- `PROXY_PORT` (required with TLS_DOMAIN) - Host port for upstream proxy (cannot be 80, 33000, 34320, or 39090)
+- `PROXY_PORT` (optional) - Host port for upstream proxy (cannot be 80, 33000, 34320, or 39090)
 
 ### TLS Certificate Management (Certbot)
 
-When `TLS_DOMAIN` environment variable is set, the collector automatically manages TLS certificates via Let's Encrypt:
+The collector automatically manages TLS certificates via Let's Encrypt when configured remotely:
 
 #### Configuration
-- **TLS_DOMAIN**: Fully-qualified domain name (e.g., `collector.example.com`)
-- **PROXY_PORT**: Host port for upstream proxy traffic (required when TLS_DOMAIN is set)
+- **Remote Management**: SSL certificate domain is now configured remotely via Better Stack API
+- **ssl_certificate_host.txt**: Domain configuration file downloaded with other configs
+- **PROXY_PORT**: Host port for upstream proxy traffic (optional)
   - Must not be 80 (reserved for ACME validation)
   - Must not conflict with internal ports (33000, 34320, 39090)
 
 #### Certificate Behavior
-- **Initial acquisition**: Attempts every 10 minutes until successful
+- **Domain changes**: When domain changes, certbot restarts immediately to acquire new certificate
+- **Grace period**: Vector validation skipped for one ping cycle (30s) when domain changes
+- **Initial acquisition**: Attempts immediately on domain change, then every 10 minutes if failed
 - **Renewals**: Checked every 6 hours once a valid certificate exists
 - **Certificate locations**:
-  - `/etc/ssl/<TLS_DOMAIN>.pem` - Symlink to fullchain certificate
-  - `/etc/ssl/<TLS_DOMAIN>.key` - Symlink to private key
-  - Both files have 0644 permissions for Vector access
+  - `/etc/ssl/<domain>.pem` - Symlink to fullchain certificate
+  - `/etc/ssl/<domain>.key` - Symlink to private key
+  - `/etc/ssl_certificate_host.txt` - Current domain configuration
+  - Certificate files have 0644 permissions for Vector access
 - **Vector reload**: Automatically signaled (HUP) after certificate updates
 
 #### Port Exposure
-When TLS is configured, the container exposes:
-- Port 80: ACME HTTP-01 validation (certbot standalone mode)
-- Port specified by PROXY_PORT: Upstream proxy traffic
+The container always exposes:
+- Port 80: ACME HTTP-01 validation (certbot standalone mode) - always available for potential use
+- Port specified by PROXY_PORT (if configured): Upstream proxy traffic
 - Existing localhost-only ports remain unchanged (33000, 34320)
 
 #### Troubleshooting TLS Issues
+- Check current domain: `docker exec <container> cat /etc/ssl_certificate_host.txt`
 - Check certbot logs: `docker logs <container> | grep certbot`
 - Verify domain DNS points to host's public IP
 - Ensure port 80 is accessible from internet for ACME validation
 - Certificate status: `docker exec <container> certbot certificates`
 - Manual renewal test: `docker exec <container> certbot renew --dry-run`
+- Force certbot restart: `docker exec <container> supervisorctl restart certbot`
 
 ### Development Tips
 

--- a/development.md
+++ b/development.md
@@ -46,15 +46,20 @@ Tail collector logs:
 
 ### Domain-based TLS (optional)
 
-- `TLS_DOMAIN` (optional): Fully-qualified domain name. When set, the container runs Certbot under supervisord to manage a certificate via ACME HTTP-01 and exposes port `80/tcp` for validation.
-- `PROXY_PORT` (required when `TLS_DOMAIN` is set): Host port mapped to the in-container proxy. Must be an integer and must not equal `80`, `33000` or `34320`.
+- SSL certificate domain is now managed remotely via Better Stack API (no longer uses `TLS_DOMAIN` env var)
+- `PROXY_PORT` (optional): Host port mapped to the in-container proxy. Must be an integer and must not equal `80`, `33000` or `34320`.
+- Domain configuration:
+  - Domain is received in `ssl_certificate_host.txt` file with other configuration files
+  - Stored at `/etc/ssl_certificate_host.txt` in the container
+  - Certbot reads domain from this file instead of environment variable
 - Certificate locations after issuance or renewal:
-  - `/etc/ssl/<TLS_DOMAIN>.pem` (symlink to fullchain.pem)
-  - `/etc/ssl/<TLS_DOMAIN>.key` (symlink to privkey.pem)
+  - `/etc/ssl/<domain>.pem` (symlink to fullchain.pem)
+  - `/etc/ssl/<domain>.key` (symlink to privkey.pem)
 - Vector reload behavior:
   - On successful issuance or renewal, Vector is signaled (HUP) to reload without container restart.
+  - When domain changes, Vector validation is skipped for one ping cycle (30s) to allow certificate acquisition
 - Retry cadence:
-  - Issuance attempts: every 10 minutes until a valid cert exists
+  - Issuance attempts: immediate on domain change, then every 10 minutes until a valid cert exists
   - Renewals: every 6 hours when a valid cert exists
 
 ## Topology

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -15,8 +15,7 @@ services:
       - VECTOR_LOG_FORMAT=json
       # Pass hostname of host machine to collector
       - HOSTNAME
-      # Optional domain-based TLS issuance (Certbot) and proxy port
-      - TLS_DOMAIN
+      # Optional proxy port for upstream proxy mode
       - PROXY_PORT
     volumes:
       # Let Vector collector host system metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ services:
       - VECTOR_LOG_FORMAT=json
       # Pass hostname of host machine to collector
       - HOSTNAME
-      # Optional domain-based TLS issuance (Certbot) and proxy port
-      - TLS_DOMAIN
+      # Optional proxy port for upstream proxy mode
       - PROXY_PORT
     volumes:
       # Let Vector collector host system metrics

--- a/engine/better_stack_client.rb
+++ b/engine/better_stack_client.rb
@@ -4,6 +4,7 @@ require_relative 'vector_config'
 require_relative 'ebpf_compatibility_checker'
 require_relative 'containers_enrichment_table'
 require_relative 'databases_enrichment_table'
+require_relative 'ssl_certificate_manager'
 require 'net/http'
 require 'fileutils'
 require 'time'
@@ -30,6 +31,7 @@ class BetterStackClient
     @kubernetes_discovery = KubernetesDiscovery.new(working_dir)
     @vector_config = VectorConfig.new(working_dir)
     @ebpf_compatibility_checker = EbpfCompatibilityChecker.new(working_dir)
+    @ssl_certificate_manager = SSLCertificateManager.new(nil)  # Use default /etc path for production
 
     containers_path = File.join(working_dir, 'enrichment', 'docker-mappings.csv')
     containers_incoming_path = File.join(working_dir, 'enrichment', 'docker-mappings.incoming.csv')
@@ -222,6 +224,8 @@ class BetterStackClient
       puts "Downloading configuration files for version #{new_version}..."
       all_files_downloaded = true
       databases_csv_exists = false
+      ssl_certificate_host_exists = false
+      ssl_certificate_host_content = nil
 
       data['files'].each do |file_info|
         # Assuming file_info is a hash {'url': '...', 'name': '...'} or just a URL string
@@ -235,8 +239,9 @@ class BetterStackClient
           break
         end
 
-        # Track if databases.csv is included in this version
+        # Track special files
         databases_csv_exists = true if filename == "databases.csv"
+        ssl_certificate_host_exists = true if filename == "ssl_certificate_host.txt"
 
         path = "#{@working_dir}/versions/#{new_version}/#{filename}".gsub(%r{/+}, '/')
         puts "Downloading #{filename} to #{path}"
@@ -246,6 +251,11 @@ class BetterStackClient
           all_files_downloaded = false
           break # Stop trying to download other files
         end
+
+        # Read ssl_certificate_host content for processing
+        if filename == "ssl_certificate_host.txt"
+          ssl_certificate_host_content = File.read(path).strip rescue ''
+        end
       end
 
       unless all_files_downloaded
@@ -253,9 +263,19 @@ class BetterStackClient
         return
       end
 
-      puts "All files downloaded. Validating configuration..."
+      puts "All files downloaded. Processing configuration..."
 
       version_dir = File.join(@working_dir, "versions", new_version)
+
+      # Process SSL certificate host if included
+      skip_vector_validation = false
+      if ssl_certificate_host_exists
+        domain_changed = @ssl_certificate_manager.process_ssl_certificate_host(ssl_certificate_host_content || '')
+        if domain_changed
+          puts "SSL certificate domain changed - will skip Vector validation for this update cycle"
+          skip_vector_validation = @ssl_certificate_manager.should_skip_validation?
+        end
+      end
 
       # Validate databases.csv if it exists in this version
       if databases_csv_exists
@@ -277,21 +297,34 @@ class BetterStackClient
         end
       end
 
-      # Validate vector config
-      validate_output = @vector_config.validate_upstream_files(version_dir)
-      unless validate_output.nil?
-        write_error("Validation failed for vector config in #{new_version}\n\n#{validate_output}")
-        return
+      # Validate and promote vector config only if not skipping
+      if skip_vector_validation
+        puts "Skipping Vector validation and promotion due to pending SSL certificate"
+      else
+        validate_output = @vector_config.validate_upstream_files(version_dir)
+        if validate_output
+          write_error("Validation failed for vector config in #{new_version}\n\n#{validate_output}")
+          return
+        end
+
+        # Only promote vector config if validation passed
+        @vector_config.promote_upstream_files(version_dir)
       end
-
-
-      # All validations passed, now promote everything
-      @vector_config.promote_upstream_files(version_dir)
 
       # Promote databases.csv if it was included and validated
       if databases_csv_exists
         @databases_enrichment_table.promote
         puts "Promoted databases.csv to #{@databases_enrichment_table.target_path}"
+      end
+
+      # Reset SSL manager flag for next ping cycle
+      @ssl_certificate_manager.reset_change_flag if ssl_certificate_host_exists
+
+      # Clean up version directory if we skipped vector validation
+      # This ensures we'll get the config again on next ping
+      if skip_vector_validation
+        puts "Removing version directory to retry vector config on next ping cycle"
+        FileUtils.rm_rf(version_dir)
       end
 
       true

--- a/engine/ssl_certificate_manager.rb
+++ b/engine/ssl_certificate_manager.rb
@@ -1,0 +1,102 @@
+require 'fileutils'
+
+class SSLCertificateManager
+  DOMAIN_FILE = '/etc/ssl_certificate_host.txt'
+
+  def initialize(working_dir = nil)
+    @working_dir = working_dir
+    @domain_file = working_dir ? File.join(working_dir, 'ssl_certificate_host.txt') : DOMAIN_FILE
+    @previous_domain = nil
+    @domain_just_changed = false
+  end
+
+  attr_reader :domain_file, :domain_just_changed
+
+  # Process an incoming SSL certificate host configuration
+  # Returns true if domain changed, false otherwise
+  def process_ssl_certificate_host(domain_string)
+    domain_string = domain_string.to_s.strip
+    current_domain = read_current_domain
+
+    # Check if domain has changed
+    if current_domain != domain_string
+      write_domain(domain_string)
+      @previous_domain = current_domain
+      @domain_just_changed = true
+
+      # If domain changed and is non-empty, restart certbot
+      if !domain_string.empty?
+        restart_certbot
+      end
+
+      return true
+    end
+
+    # Domain hasn't changed
+    @domain_just_changed = false
+    false
+  end
+
+  # Check if we should skip vector validation due to pending certificate
+  def should_skip_validation?
+    return false unless @domain_just_changed
+
+    current_domain = read_current_domain
+    return false if current_domain.empty?
+
+    # Skip validation if certificate doesn't exist yet
+    !certificate_exists?(current_domain)
+  end
+
+  # Reset the "just changed" flag after a ping cycle
+  def reset_change_flag
+    @domain_just_changed = false
+  end
+
+  # Check if a certificate exists for the given domain
+  def certificate_exists?(domain = nil)
+    domain ||= read_current_domain
+    return false if domain.empty?
+
+    cert_path = "/etc/ssl/#{domain}.pem"
+    key_path = "/etc/ssl/#{domain}.key"
+
+    File.exist?(cert_path) && File.exist?(key_path)
+  end
+
+  # Read the current domain from file
+  def read_current_domain
+    return '' unless File.exist?(@domain_file)
+    File.read(@domain_file).strip
+  rescue => e
+    puts "Error reading SSL certificate host file: #{e.message}"
+    ''
+  end
+
+  private
+
+  # Write domain to the well-known location
+  def write_domain(domain_string)
+    FileUtils.mkdir_p(File.dirname(@domain_file))
+    File.write(@domain_file, domain_string)
+    puts "Updated SSL certificate host: #{domain_string.empty? ? '(empty)' : domain_string}"
+  rescue => e
+    puts "Error writing SSL certificate host file: #{e.message}"
+    raise
+  end
+
+  # Restart certbot via supervisorctl
+  def restart_certbot
+    puts "Restarting certbot to handle domain change..."
+    result = system('supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart certbot')
+    if result
+      puts "Certbot restarted successfully"
+    else
+      puts "Warning: Failed to restart certbot"
+    end
+    result
+  rescue => e
+    puts "Error restarting certbot: #{e.message}"
+    false
+  end
+end

--- a/test/ssl_certificate_manager_test.rb
+++ b/test/ssl_certificate_manager_test.rb
@@ -1,0 +1,264 @@
+require 'minitest/autorun'
+require 'fileutils'
+require 'tmpdir'
+require_relative '../engine/ssl_certificate_manager'
+
+class SSLCertificateManagerTest < Minitest::Test
+  def setup
+    @test_dir = Dir.mktmpdir
+    @manager = SSLCertificateManager.new(@test_dir)
+    @domain_file = File.join(@test_dir, 'ssl_certificate_host.txt')
+  end
+
+  def teardown
+    FileUtils.rm_rf(@test_dir)
+  end
+
+  def test_initialize_with_working_dir
+    manager = SSLCertificateManager.new(@test_dir)
+    assert_equal File.join(@test_dir, 'ssl_certificate_host.txt'), manager.domain_file
+  end
+
+  def test_initialize_without_working_dir
+    manager = SSLCertificateManager.new
+    assert_equal '/etc/ssl_certificate_host.txt', manager.domain_file
+  end
+
+  def test_read_current_domain_when_file_missing
+    assert_equal '', @manager.read_current_domain
+  end
+
+  def test_read_current_domain_when_file_exists
+    File.write(@domain_file, 'example.com')
+    assert_equal 'example.com', @manager.read_current_domain
+  end
+
+  def test_read_current_domain_strips_whitespace
+    File.write(@domain_file, "  example.com\n  ")
+    assert_equal 'example.com', @manager.read_current_domain
+  end
+
+  def test_process_ssl_certificate_host_first_time
+    # Mock restart_certbot to avoid system calls
+    restart_called = false
+    @manager.define_singleton_method(:restart_certbot) do
+      restart_called = true
+      true
+    end
+
+    result = @manager.process_ssl_certificate_host('new.example.com')
+
+    assert result, 'Should return true when domain changes'
+    assert_equal 'new.example.com', File.read(@domain_file)
+    assert restart_called, 'Should restart certbot for new non-empty domain'
+    assert @manager.domain_just_changed, 'Should set domain_just_changed flag'
+  end
+
+  def test_process_ssl_certificate_host_no_change
+    File.write(@domain_file, 'example.com')
+
+    # Mock restart_certbot
+    restart_called = false
+    @manager.define_singleton_method(:restart_certbot) do
+      restart_called = true
+      true
+    end
+
+    result = @manager.process_ssl_certificate_host('example.com')
+
+    assert !result, 'Should return false when domain unchanged'
+    assert !restart_called, 'Should not restart certbot when domain unchanged'
+    assert !@manager.domain_just_changed, 'Should not set domain_just_changed flag'
+  end
+
+  def test_process_ssl_certificate_host_domain_change
+    File.write(@domain_file, 'old.example.com')
+
+    # Mock restart_certbot
+    restart_called = false
+    @manager.define_singleton_method(:restart_certbot) do
+      restart_called = true
+      true
+    end
+
+    result = @manager.process_ssl_certificate_host('new.example.com')
+
+    assert result, 'Should return true when domain changes'
+    assert_equal 'new.example.com', File.read(@domain_file)
+    assert restart_called, 'Should restart certbot when domain changes'
+    assert @manager.domain_just_changed, 'Should set domain_just_changed flag'
+  end
+
+  def test_process_ssl_certificate_host_to_empty
+    File.write(@domain_file, 'example.com')
+
+    # Mock restart_certbot
+    restart_called = false
+    @manager.define_singleton_method(:restart_certbot) do
+      restart_called = true
+      true
+    end
+
+    result = @manager.process_ssl_certificate_host('')
+
+    assert result, 'Should return true when clearing domain'
+    assert_equal '', File.read(@domain_file)
+    assert !restart_called, 'Should not restart certbot when clearing domain'
+    assert @manager.domain_just_changed, 'Should set domain_just_changed flag'
+  end
+
+  def test_process_ssl_certificate_host_from_empty
+    # Start with no file (empty domain)
+
+    # Mock restart_certbot
+    restart_called = false
+    @manager.define_singleton_method(:restart_certbot) do
+      restart_called = true
+      true
+    end
+
+    result = @manager.process_ssl_certificate_host('new.example.com')
+
+    assert result, 'Should return true when setting domain from empty'
+    assert_equal 'new.example.com', File.read(@domain_file)
+    assert restart_called, 'Should restart certbot when setting non-empty domain'
+    assert @manager.domain_just_changed, 'Should set domain_just_changed flag'
+  end
+
+  def test_certificate_exists_returns_false_for_empty_domain
+    File.write(@domain_file, '')
+    assert !@manager.certificate_exists?, 'Should return false for empty domain'
+  end
+
+  def test_certificate_exists_returns_false_when_files_missing
+    assert !@manager.certificate_exists?('example.com'), 'Should return false when cert files missing'
+  end
+
+  def test_certificate_exists_returns_false_when_only_cert_exists
+    domain = 'example.com'
+    cert_path = "/etc/ssl/#{domain}.pem"
+
+    # Create temp cert file for testing
+    FileUtils.mkdir_p('/tmp/ssl_test')
+    temp_cert = "/tmp/ssl_test/#{domain}.pem"
+    FileUtils.touch(temp_cert)
+
+    # Mock the certificate path checking
+    @manager.define_singleton_method(:certificate_exists?) do |d|
+      d ||= read_current_domain
+      return false if d.empty?
+      # Use temp paths for testing
+      File.exist?("/tmp/ssl_test/#{d}.pem") && File.exist?("/tmp/ssl_test/#{d}.key")
+    end
+
+    assert !@manager.certificate_exists?(domain), 'Should return false when only cert exists'
+
+    FileUtils.rm_rf('/tmp/ssl_test')
+  end
+
+  def test_certificate_exists_returns_true_when_both_files_exist
+    domain = 'example.com'
+
+    # Create temp cert files for testing
+    FileUtils.mkdir_p('/tmp/ssl_test')
+    temp_cert = "/tmp/ssl_test/#{domain}.pem"
+    temp_key = "/tmp/ssl_test/#{domain}.key"
+    FileUtils.touch(temp_cert)
+    FileUtils.touch(temp_key)
+
+    # Mock the certificate path checking
+    @manager.define_singleton_method(:certificate_exists?) do |d|
+      d ||= read_current_domain
+      return false if d.empty?
+      # Use temp paths for testing
+      File.exist?("/tmp/ssl_test/#{d}.pem") && File.exist?("/tmp/ssl_test/#{d}.key")
+    end
+
+    assert @manager.certificate_exists?(domain), 'Should return true when both cert files exist'
+
+    FileUtils.rm_rf('/tmp/ssl_test')
+  end
+
+  def test_should_skip_validation_when_domain_just_changed_and_no_cert
+    # Simulate domain just changed
+    @manager.instance_variable_set(:@domain_just_changed, true)
+    File.write(@domain_file, 'new.example.com')
+
+    # Mock certificate_exists? to return false
+    @manager.define_singleton_method(:certificate_exists?) do |domain|
+      false
+    end
+
+    assert @manager.should_skip_validation?, 'Should skip validation when domain changed and cert missing'
+  end
+
+  def test_should_not_skip_validation_when_domain_unchanged
+    # Domain has not just changed
+    @manager.instance_variable_set(:@domain_just_changed, false)
+    File.write(@domain_file, 'example.com')
+
+    assert !@manager.should_skip_validation?, 'Should not skip validation when domain unchanged'
+  end
+
+  def test_should_not_skip_validation_when_cert_exists
+    # Simulate domain just changed
+    @manager.instance_variable_set(:@domain_just_changed, true)
+    File.write(@domain_file, 'example.com')
+
+    # Mock certificate_exists? to return true
+    @manager.define_singleton_method(:certificate_exists?) do |domain|
+      true
+    end
+
+    assert !@manager.should_skip_validation?, 'Should not skip validation when cert exists'
+  end
+
+  def test_should_not_skip_validation_for_empty_domain
+    # Simulate domain just changed to empty
+    @manager.instance_variable_set(:@domain_just_changed, true)
+    File.write(@domain_file, '')
+
+    assert !@manager.should_skip_validation?, 'Should not skip validation for empty domain'
+  end
+
+  def test_reset_change_flag
+    @manager.instance_variable_set(:@domain_just_changed, true)
+    assert @manager.domain_just_changed
+
+    @manager.reset_change_flag
+    assert !@manager.domain_just_changed, 'Should reset domain_just_changed flag'
+  end
+
+  def test_restart_certbot_command
+    # Test that restart_certbot attempts the right system command
+    # We'll mock system to capture the command
+    command_executed = nil
+    @manager.define_singleton_method(:system) do |cmd|
+      command_executed = cmd
+      true
+    end
+
+    @manager.send(:restart_certbot)
+
+    expected_command = 'supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart certbot'
+    assert_equal expected_command, command_executed, 'Should execute correct supervisorctl command'
+  end
+
+  def test_process_handles_write_errors_gracefully
+    # Make domain file unwritable
+    FileUtils.mkdir_p(@domain_file)  # Create as directory to cause write error
+
+    # Should raise error when unable to write
+    assert_raises do
+      @manager.process_ssl_certificate_host('example.com')
+    end
+  end
+
+  def test_strips_whitespace_from_input
+    # Mock restart_certbot
+    @manager.define_singleton_method(:restart_certbot) { true }
+
+    @manager.process_ssl_certificate_host("  example.com\n  ")
+    assert_equal 'example.com', File.read(@domain_file)
+  end
+end


### PR DESCRIPTION
* the expected domain will now come from Telemetry
* when the domain changes to non-empty, we:
  * skip the Vector config validation/promotion - without SSL certificate, it will always fail
  * restart certbot to immediately try and pick up the certificate
  * the next ping (in 30s) proceeds as normal, and hopefully the certificate is in place
  * if it isn't, we proceed as normal - Vector will fail to promote