### PR TITLE
Add read-only host filesystem mount for Vector

### DIFF
--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -29,6 +29,8 @@ services:
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
       - docker-metadata:/enrichment:rw
+      # Mount host root filesystem to enable reading custom log paths with Vector
+      - /:/host:ro
     ports:
       # Bind to localhost only for security - Beyla will connect via host network
       - "127.0.0.1:34320:34320" # Beyla metrics endpoint

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -19,18 +19,11 @@ services:
       - TLS_DOMAIN
       - PROXY_PORT
     volumes:
-      # Let Vector collector host system metrics
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      # Collect host logs
-      - /var/log:/host/var/log:ro
-      # Collect Docker container logs
-      - /var/lib/docker/containers:/host/var/lib/docker/containers:ro
+      # Mount host root filesystem to enable reading system metrics, logs (including logs outside /var/log), and container data
+      - /:/host:ro
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
       - docker-metadata:/enrichment:rw
-      # Mount host root filesystem to enable reading custom log paths with Vector
-      - /:/host:ro
     ports:
       # Bind to localhost only for security - Beyla will connect via host network
       - "127.0.0.1:34320:34320" # Beyla metrics endpoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,18 +17,11 @@ services:
       - TLS_DOMAIN
       - PROXY_PORT
     volumes:
-      # Let Vector collector host system metrics
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      # Collect host logs
-      - /var/log:/host/var/log:ro
-      # Collect Docker container logs
-      - /var/lib/docker/containers:/host/var/lib/docker/containers:ro
+      # Mount host root filesystem to enable reading system metrics, logs (including logs outside /var/log), and container data
+      - /:/host:ro
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
       - docker-metadata:/enrichment:rw
-      # Mount host root filesystem to enable reading custom log paths with Vector
-      - /:/host:ro
     ports:
       # Bind to localhost only for security - Beyla will connect via host network
       - "127.0.0.1:34320:34320" # Beyla metrics endpoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       # dockerprobe running in the beyla container writes a map of PIDs->container IDs and names to this volume
       # Vector uses this file as an enrichment table to tag logs, metrics, and traces with container metadata.
       - docker-metadata:/enrichment:rw
+      # Mount host root filesystem to enable reading custom log paths with Vector
+      - /:/host:ro
     ports:
       # Bind to localhost only for security - Beyla will connect via host network
       - "127.0.0.1:34320:34320" # Beyla metrics endpoint


### PR DESCRIPTION
Mount `/:/host:ro` to allow reading custom log files with manual Vector config, e.g. from `/var/www`.