### PR TITLE
Opus: Avoid vector crashloops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY --chmod=755 updater.rb /updater.rb
 COPY --chmod=755 proxy.rb /proxy.rb
 COPY --chmod=755 vector.sh /vector.sh
+COPY --chmod=755 healthcheck.sh /healthcheck.sh
 COPY --chmod=755 certbot-runner.sh /certbot-runner.sh
 COPY --chmod=755 certbot-deploy-hook.sh /certbot-deploy-hook.sh
 COPY versions/0-default/vector.yaml /versions/0-default/vector.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,8 @@ RUN mkdir -p /vector-config/0-default \
   && ln -s /versions/0-default/vector.yaml /vector-config/0-default/vector.yaml \
   && ln -s /kubernetes-discovery/0-default /vector-config/0-default/kubernetes-discovery \
   && ln -s /vector-config/0-default /vector-config/current \
-  && cp /versions/0-default/vector.yaml /vector-config/latest-valid-upstream/vector.yaml
+  && cp /versions/0-default/vector.yaml /vector-config/latest-valid-upstream/vector.yaml \
+  && touch /first-boot.txt
 
 # Install tini and use it as init to handle signals properly
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.0.30
+ENV COLLECTOR_VERSION=1.0.31
 ENV VECTOR_VERSION=0.47.0
 ENV BEYLA_VERSION=2.2.4
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/development.md
+++ b/development.md
@@ -38,6 +38,29 @@ Tail collector logs:
 - **Docker image failing to start because one of the processes crashes?**
   Disable the `fatal_handler` in supervisor.conf, start the collector again, log into the container and look into /var/log/supervisor/\* logs.
 
+- **Vector loses configuration and shows only console sink?**
+  This indicates Vector lost access to `/vector-config/current/`. The collector includes several recovery mechanisms:
+  - Health check (`healthcheck.sh`) monitors Vector every 60s and restarts if only console sink detected
+  - Supervisor will retry Vector 10 times before triggering container restart
+  - Check Vector sinks: `docker exec -it better-stack-collector curl -s http://localhost:8686/graphql -H "Content-Type: application/json" -d '{"query":"{ sinks { edges { node { componentId } } } }"}'`
+
+- **"Too many open files" or inotify errors?**
+  The collector sets higher system limits via:
+  - Kubernetes: Init container with `CAP_SYS_ADMIN` capability
+  - Docker Compose: `sysctls` settings in docker-compose.yml
+  - If still occurring, check current limits: `docker exec -it better-stack-collector cat /proc/sys/fs/inotify/max_user_watches`
+
+- **Vector won't start - exit code 127?**
+  This means Vector found no config files in `/vector-config/current/`. The startup script (`vector.sh`) will:
+  1. Try to restore from `/vector-config/latest-valid-upstream/`
+  2. Exit with code 127 if no configs available
+  3. Supervisor will retry 10 times, then container restarts
+
+- **Debugging configuration updates:**
+  - Check updater logs: `docker exec -it better-stack-collector tail -f /var/log/supervisor/updater.out.log`
+  - Verify current config: `docker exec -it better-stack-collector ls -la /vector-config/current/`
+  - Check symlink target: `docker exec -it better-stack-collector readlink /vector-config/current`
+
 ## Environment Variables
 
 - `COLLECTOR_SECRET` (required): Your Better Stack collector secret

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -8,6 +8,14 @@ services:
     restart: always
     security_opt:
       - seccomp=collector-seccomp.json
+    sysctls:
+      - fs.inotify.max_user_watches=524288
+      - fs.inotify.max_user_instances=8192
+      - fs.file-max=2097152
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     environment:
       - COLLECTOR_SECRET
       - BASE_URL

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -16,6 +16,12 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    healthcheck:
+      test: ["/healthcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
     environment:
       - COLLECTOR_SECRET
       - BASE_URL

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -8,14 +8,6 @@ services:
     restart: always
     security_opt:
       - seccomp=collector-seccomp.json
-    sysctls:
-      - fs.inotify.max_user_watches=524288
-      - fs.inotify.max_user_instances=8192
-      - fs.file-max=2097152
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
     healthcheck:
       test: ["/healthcheck.sh"]
       interval: 30s

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -9,7 +9,7 @@ services:
     security_opt:
       - seccomp=collector-seccomp.json
     healthcheck:
-      test: ["/healthcheck.sh"]
+      test: ["CMD", "/healthcheck.sh"]
       interval: 30s
       timeout: 10s
       start_period: 60s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,14 @@ services:
     image: betterstack/collector:latest
     container_name: better-stack-collector
     restart: always
+    sysctls:
+      - fs.inotify.max_user_watches=524288
+      - fs.inotify.max_user_instances=8192
+      - fs.file-max=2097152
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     environment:
       - COLLECTOR_SECRET
       - BASE_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    healthcheck:
+      test: ["/healthcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
     environment:
       - COLLECTOR_SECRET
       - BASE_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: better-stack-collector
     restart: always
     healthcheck:
-      test: ["/healthcheck.sh"]
+      test: ["CMD", "/healthcheck.sh"]
       interval: 30s
       timeout: 10s
       start_period: 60s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,6 @@ services:
     image: betterstack/collector:latest
     container_name: better-stack-collector
     restart: always
-    sysctls:
-      - fs.inotify.max_user_watches=524288
-      - fs.inotify.max_user_instances=8192
-      - fs.file-max=2097152
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
     healthcheck:
       test: ["/healthcheck.sh"]
       interval: 30s

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Health check script for Vector
+# Detects when Vector is running with minimal/console-only configuration
+
+set -euo pipefail
+
+CHECK_INTERVAL=60  # seconds between checks
+
+echo "$(date): Starting Vector health check monitor (interval: ${CHECK_INTERVAL}s)"
+
+while true; do
+    # Give Vector some time to start up on first run
+    if [ ! -f "/tmp/healthcheck-started" ]; then
+        echo "$(date): Initial startup delay..."
+        touch /tmp/healthcheck-started
+        sleep 30
+    fi
+
+    # Check if Vector is healthy
+    VECTOR_HEALTH=$(curl -s http://localhost:8686/health 2>/dev/null || echo "FAILED")
+
+    if [ "$VECTOR_HEALTH" != "ok" ]; then
+        echo "$(date): Vector health check failed - not responding or unhealthy"
+    else
+        # Check what sinks Vector has configured
+        # If only console sink exists, something is wrong
+        SINKS=$(curl -s http://localhost:8686/graphql \
+            -H "Content-Type: application/json" \
+            -d '{"query":"{ sinks { edges { node { componentId componentType } } } }"}' 2>/dev/null | \
+            jq -r '.data.sinks.edges[].node.componentId' 2>/dev/null || echo "")
+
+        if [ -z "$SINKS" ]; then
+            echo "$(date): ERROR: Vector has no sinks configured"
+            echo "$(date): Force restarting Vector..."
+            supervisorctl restart vector
+        else
+            # Count how many sinks we have
+            SINK_COUNT=$(echo "$SINKS" | wc -l)
+
+            # Check if only console sink exists (emergency/fallback mode)
+            if [ "$SINK_COUNT" -eq 1 ] && echo "$SINKS" | grep -q "^console$"; then
+                echo "$(date): ERROR: Vector running with console-only sink (lost configuration)"
+                echo "$(date): Force restarting Vector..."
+                supervisorctl restart vector
+            elif ! echo "$SINKS" | grep -q "better_stack_http"; then
+                # Check if we're missing expected Better Stack sinks
+                echo "$(date): WARNING: Vector missing Better Stack HTTP sinks"
+                echo "$(date): Current sinks: $(echo $SINKS | tr '\n' ' ')"
+                # Don't restart yet - updater might be working on it
+            else
+                echo "$(date): Vector health check passed - $SINK_COUNT sinks configured"
+            fi
+        fi
+    fi
+
+    sleep $CHECK_INTERVAL
+done

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -34,11 +34,11 @@ while true; do
         sleep 30
     fi
 
-    # Check if Vector is healthy
-    VECTOR_HEALTH=$(curl -s http://localhost:8686/health 2>/dev/null || echo "FAILED")
+    # Check if Vector is healthy (returns JSON: {"ok":true} or {"ok":false})
+    VECTOR_HEALTH=$(curl -s http://localhost:8686/health 2>/dev/null | jq -r '.ok' 2>/dev/null || echo "error")
 
-    if [ "$VECTOR_HEALTH" != "ok" ]; then
-        echo "$(date): Vector health check failed - not responding or unhealthy"
+    if [ "$VECTOR_HEALTH" != "true" ]; then
+        echo "$(date): Vector health check failed - not responding or unhealthy ($VECTOR_HEALTH)"
     else
         # Check what sinks Vector has configured
         # If only console sink exists, something is wrong

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,73 +1,45 @@
 #!/bin/bash
 # Health check script for Vector
+# Returns 0 if healthy, non-zero if unhealthy
 # Detects when Vector is running with minimal/console-only configuration
 
 set -euo pipefail
 
-CHECK_INTERVAL=60  # seconds between checks
+# Check if Vector is healthy (returns JSON: {"ok":true} or {"ok":false})
+VECTOR_HEALTH=$(curl -s http://localhost:8686/health 2>/dev/null | jq -r '.ok' 2>/dev/null || echo "error")
 
-echo "$(date): Starting Vector health check monitor (interval: ${CHECK_INTERVAL}s)"
+if [ "$VECTOR_HEALTH" != "true" ]; then
+    echo "Vector health check failed - not responding or unhealthy ($VECTOR_HEALTH)"
+    exit 1
+fi
 
-# Function to safely restart Vector
-safe_restart_vector() {
-    local reason="$1"
+# Check what sinks Vector has configured
+# If only console sink exists, something is wrong
+SINKS=$(curl -s http://localhost:8686/graphql \
+    -H "Content-Type: application/json" \
+    -d '{"query":"{ sinks { edges { node { componentId componentType } } } }"}' 2>/dev/null | \
+    jq -r '.data.sinks.edges[].node.componentId' 2>/dev/null || echo "")
 
-    # Check Vector's current state before restarting
-    local VECTOR_STATE=$(supervisorctl status vector | awk '{print $2}')
-    echo "$(date): Vector current state: $VECTOR_STATE (reason: $reason)"
+if [ -z "$SINKS" ]; then
+    echo "ERROR: Vector has no sinks configured"
+    exit 1
+fi
 
-    if [ "$VECTOR_STATE" = "RUNNING" ]; then
-        echo "$(date): Force restarting Vector..."
-        supervisorctl restart vector
-    elif [ "$VECTOR_STATE" = "STARTING" ]; then
-        echo "$(date): Vector is already starting, waiting for it to stabilize..."
-    else
-        echo "$(date): Vector is in state $VECTOR_STATE, supervisor will handle it"
-    fi
-}
+# Count how many sinks we have
+SINK_COUNT=$(echo "$SINKS" | wc -l)
 
-while true; do
-    # Give Vector some time to start up on first run
-    if [ ! -f "/tmp/healthcheck-started" ]; then
-        echo "$(date): Initial startup delay..."
-        touch /tmp/healthcheck-started
-        sleep 30
-    fi
+# Check if only console sink exists (emergency/fallback mode)
+if [ "$SINK_COUNT" -eq 1 ] && echo "$SINKS" | grep -q "^console$"; then
+    echo "ERROR: Vector running with console-only sink (lost configuration)"
+    exit 1
+fi
 
-    # Check if Vector is healthy (returns JSON: {"ok":true} or {"ok":false})
-    VECTOR_HEALTH=$(curl -s http://localhost:8686/health 2>/dev/null | jq -r '.ok' 2>/dev/null || echo "error")
+# Check if we're missing expected Better Stack sinks
+if ! echo "$SINKS" | grep -q "better_stack_http"; then
+    echo "WARNING: Vector missing Better Stack HTTP sinks"
+    echo "Current sinks: $(echo $SINKS | tr '\n' ' ')"
+    # Don't fail yet - updater might be working on it
+fi
 
-    if [ "$VECTOR_HEALTH" != "true" ]; then
-        echo "$(date): Vector health check failed - not responding or unhealthy ($VECTOR_HEALTH)"
-    else
-        # Check what sinks Vector has configured
-        # If only console sink exists, something is wrong
-        SINKS=$(curl -s http://localhost:8686/graphql \
-            -H "Content-Type: application/json" \
-            -d '{"query":"{ sinks { edges { node { componentId componentType } } } }"}' 2>/dev/null | \
-            jq -r '.data.sinks.edges[].node.componentId' 2>/dev/null || echo "")
-
-        if [ -z "$SINKS" ]; then
-            echo "$(date): ERROR: Vector has no sinks configured"
-            safe_restart_vector "no sinks configured"
-        else
-            # Count how many sinks we have
-            SINK_COUNT=$(echo "$SINKS" | wc -l)
-
-            # Check if only console sink exists (emergency/fallback mode)
-            if [ "$SINK_COUNT" -eq 1 ] && echo "$SINKS" | grep -q "^console$"; then
-                echo "$(date): ERROR: Vector running with console-only sink (lost configuration)"
-                safe_restart_vector "console-only sink (lost configuration)"
-            elif ! echo "$SINKS" | grep -q "better_stack_http"; then
-                # Check if we're missing expected Better Stack sinks
-                echo "$(date): WARNING: Vector missing Better Stack HTTP sinks"
-                echo "$(date): Current sinks: $(echo $SINKS | tr '\n' ' ')"
-                # Don't restart yet - updater might be working on it
-            else
-                echo "$(date): Vector health check passed - $SINK_COUNT sinks configured"
-            fi
-        fi
-    fi
-
-    sleep $CHECK_INTERVAL
-done
+echo "Vector health check passed - $SINK_COUNT sinks configured"
+exit 0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -18,8 +18,11 @@ autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/vector.err.log
 stdout_logfile=/var/log/supervisor/vector.out.log
-startretries=3
-exitcodes=0,1,2,3,4,5,6,7,77
+startretries=10
+startsecs=10
+stopwaitsecs=30
+stopsignal=TERM
+exitcodes=0,1,2
 stopasgroup=true
 killasgroup=true
 environment=OTEL_SERVICE_NAME="better-stack-collector-vector"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -18,7 +18,7 @@ autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/vector.err.log
 stdout_logfile=/var/log/supervisor/vector.out.log
-startretries=10
+startretries=3
 startsecs=10
 stopwaitsecs=30
 stopsignal=TERM
@@ -50,15 +50,6 @@ autorestart=true
 stderr_logfile=/var/log/supervisor/certbot.err.log
 stdout_logfile=/var/log/supervisor/certbot.out.log
 environment=OTEL_SERVICE_NAME="better-stack-collector-certbot"
-
-[program:healthcheck]
-command=/healthcheck.sh
-autostart=true
-autorestart=true
-stderr_logfile=/var/log/supervisor/healthcheck.err.log
-stdout_logfile=/var/log/supervisor/healthcheck.out.log
-startretries=3
-environment=OTEL_SERVICE_NAME="better-stack-collector-healthcheck"
 
 [eventlistener:fatal_handler]
 command=bash -c "printf 'READY\n'; while read line; do printf 'RESULT 2\nOK'; kill -15 1; done"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -51,6 +51,15 @@ stderr_logfile=/var/log/supervisor/certbot.err.log
 stdout_logfile=/var/log/supervisor/certbot.out.log
 environment=OTEL_SERVICE_NAME="better-stack-collector-certbot"
 
+[program:healthcheck]
+command=/healthcheck.sh
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/supervisor/healthcheck.err.log
+stdout_logfile=/var/log/supervisor/healthcheck.out.log
+startretries=3
+environment=OTEL_SERVICE_NAME="better-stack-collector-healthcheck"
+
 [eventlistener:fatal_handler]
 command=bash -c "printf 'READY\n'; while read line; do printf 'RESULT 2\nOK'; kill -15 1; done"
 events=PROCESS_STATE_FATAL

--- a/vector.sh
+++ b/vector.sh
@@ -34,30 +34,36 @@ if [ ! -f "/enrichment/docker-mappings.csv" ] && [ -f "/enrichment-defaults/dock
     cp /enrichment-defaults/docker-mappings.csv /enrichment/docker-mappings.csv
 fi
 
-# Validate config files exist and are readable
-CONFIG_DIR="/vector-config/current"
-if [ ! -d "$CONFIG_DIR" ]; then
-    echo "ERROR: Config directory $CONFIG_DIR does not exist!"
-    echo "Attempting to restore from last known good config..."
-    if [ -d "/vector-config/latest-valid-upstream" ]; then
-        mkdir -p "$CONFIG_DIR"
-        cp -r /vector-config/latest-valid-upstream/* "$CONFIG_DIR/"
-        echo "Restored configuration from latest-valid-upstream"
-    else
-        echo "FATAL: No valid configuration available"
-        exit 1
+# Check for first boot
+if [ -f "/first-boot.txt" ]; then
+    echo "First boot detected, skipping config validation..."
+    # Remove the first boot marker
+    rm -f /first-boot.txt
+else
+    # Validate config files exist and are readable
+    if [ ! -d "/vector-config/current" ]; then
+        echo "ERROR: Config directory /vector-config/current does not exist!"
+        echo "Attempting to restore from last known good config..."
+        if [ -d "/vector-config/latest-valid-upstream" ]; then
+            mkdir -p "/vector-config/current"
+            cp -r /vector-config/latest-valid-upstream/* "/vector-config/current/"
+            echo "Restored configuration from latest-valid-upstream"
+        else
+            echo "FATAL: No valid configuration available"
+            exit 1
+        fi
     fi
-fi
 
-# Check if we have actual config files
-CONFIG_COUNT=$(find "$CONFIG_DIR" -name "*.yaml" -type f 2>/dev/null | wc -l)
-if [ "$CONFIG_COUNT" -eq 0 ]; then
-    echo "ERROR: No YAML config files found in $CONFIG_DIR"
-    echo "Vector cannot start without configuration"
-    # Exit with 127 - "command not found" - indicates critical config missing
-    exit 127
-fi
+    # Check if we have actual config files (follow symlinks with -L)
+    CONFIG_COUNT=$(find -L "/vector-config/current" -name "*.yaml" -type f 2>/dev/null | wc -l)
+    if [ "$CONFIG_COUNT" -eq 0 ]; then
+        echo "ERROR: No YAML config files found in /vector-config/current"
+        echo "Vector cannot start without configuration"
+        # Exit with 127 - "command not found" - indicates critical config missing
+        exit 127
+    fi
 
-echo "Found $CONFIG_COUNT config files in $CONFIG_DIR"
+    echo "Found $CONFIG_COUNT config files in /vector-config/current"
+fi
 echo "Starting Vector..."
-exec /usr/local/bin/vector --config "$CONFIG_DIR"/*.yaml --config "$CONFIG_DIR"/kubernetes-discovery/*.yaml
+exec /usr/local/bin/vector --config /vector-config/current/\*.yaml --config /vector-config/current/kubernetes-discovery/\*.yaml


### PR DESCRIPTION
I managed to reproduce the bug we’ve been seeing, though only intermittently. It occurs under the most (not necessarily all) following conditions:

- Vector is under heavy memory pressure -> disk buffers are in use
- File system watchers/inotify are near exhaustion (many log files watched/files open on the system)
- An HTTP sink fails or applies backpressure, increasing memory/disk buffer pressure
- A SIGHUP arrives, causing Vector to try and re-establish watches, exhausting open files limit
- Can also be exacerbated by an oomkill on Vector (memory pressure from buffers plus, I assume, file watcher metadata)

When this happens, Vector fails to reload its configuration. The process fails, then Supervisor restarts it, treating the exit codes as normal. On restart, Vector can’t access its configuration files, so it comes up without the proper settings or buffer configuration. Once it enters this state, it stays there in fail-safe mode until something intervenes. This last part is likely a Vector bug - but I don't have concrete enough reproduction steps to feel good about reporting it.

It seems reasonable this would most readily occur in Kubernetes:
- enforced memory limits
- likely many files in /host/var/log for Vector to watch
- kubernetes logs source watching pod files
- memory pressure on the node -> pod restarts -> more pod logs to watch -> more memory pressure from Vector

It also explains symptops well:
- no logs sunk -> Vector is running with failsafe config (no proper sinks)
- no buffer files -> Vector is running with failsafe config (no buffers)
- logs show Vector running -> yes, just not sinking anything into nonexistent http sinks

To address this, I introduced the following changes:
1.	Config validation at startup – if /vector-config/current is inaccessible and no previous valid config can be restored, the startup script fails immediately. If open files limit is exhausted, the check script should be unable to access configuration as well.
2.	Health check script – detects when Vector is stuck in fail-safe mode (only the default console sink present). If so, it forces a restart, counting against Supervisor’s restart limit (now 10).
3.	Exit code handling – exit codes 0,1,2 are considered normal and restartable; higher codes are treated as fatal, abandoning the failing pod instead of retrying endlessly.

This setup should help automatically recover from cases where Vector is “limping” along in fail-safe mode and pretending to be healthy. In its harshest form, this should take the form of abandoning the pod (and the potentially unhealthy overlay filesystem), and starting fresh. Ditto for docker; we likely haven't seen it in Docker installations because it's just harder to churn/impact a Docker Compose/Swarm service enough.

This may just be the product of time + churn - Vector will exhaust open files eventually when tightly limited. The timing is suspicious though: we only see it now, after I rolled out Helm/Compose changes mounting the host filesystem read-only under /host. In theory, exposing more files shouldn’t matter (exposed ≠ watched), but that correlation led me to simulate extreme logfile churn and resource constraints, which reproduced the bug. If such issues persist, I would consider rolling back that change and reassessing how we approach custom log files.

My intent here is to both reduce the immediate triggers (watcher/file exhaustion) and add safeguards so Vector can’t silently remain non-functional in the future.

This also makes Vector API non-optional (necessary for health checks). I will propose a patch in Telemetry that makes it the default.