### PR TITLE
Update beyla to 2.7.2

### DIFF
--- a/Dockerfile.beyla
+++ b/Dockerfile.beyla
@@ -5,7 +5,7 @@ FROM ghcr.io/coroot/coroot-node-agent:1.25.0 AS node-agent
 FROM ghcr.io/coroot/coroot-cluster-agent:1.2.4 AS cluster-agent
 
 # Get Beyla files from official image
-FROM grafana/beyla:2.6.4 AS beyla-source
+FROM grafana/beyla:2.7.2 AS beyla-source
 
 # Final stage - Using Debian 12.11-slim for glibc compatibility with node-agent
 FROM debian:12.11-slim


### PR DESCRIPTION
Some promising stuff in 2.7.2 (and generally in the 2.7 line) - opening a branch to start private testing.