### PR TITLE
Harden bootstrap procedure

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.1.24
+ENV COLLECTOR_VERSION=1.1.25
 ENV VECTOR_VERSION=0.47.0
 ENV OBI_VERSION=0.4.1
 ENV CLUSTER_AGENT_VERSION=1.2.4

--- a/collector/run_supervisord.sh
+++ b/collector/run_supervisord.sh
@@ -6,8 +6,24 @@ set -e
 SUPERVISORD_CONF="/var/lib/better-stack/collector/supervisord.conf"
 BOOTSTRAP_CONF="/bootstrap/supervisord.conf"
 
+NEEDS_BOOTSTRAP=false
+COLLECTOR_DIR="/var/lib/better-stack/collector"
+
 if [ ! -f "$SUPERVISORD_CONF" ]; then
-  echo "Supervisord config not found at $SUPERVISORD_CONF, copying from bootstrap..."
+  echo "Supervisord config not found at $SUPERVISORD_CONF"
+  NEEDS_BOOTSTRAP=true
+else
+  for required_file in "$COLLECTOR_DIR/vector.sh" "$COLLECTOR_DIR/updater.rb" "$COLLECTOR_DIR/proxy.rb"; do
+    if [ ! -f "$required_file" ]; then
+      echo "Incomplete install detected: $required_file is missing"
+      NEEDS_BOOTSTRAP=true
+      break
+    fi
+  done
+fi
+
+if [ "$NEEDS_BOOTSTRAP" = true ]; then
+  echo "Copying bootstrap supervisord config to $SUPERVISORD_CONF..."
   mkdir -p "$(dirname "$SUPERVISORD_CONF")"
   cp "$BOOTSTRAP_CONF" "$SUPERVISORD_CONF"
   echo "Copied bootstrap supervisord config to $SUPERVISORD_CONF"

--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,14 @@ if [ -n "$SWARM_CONTAINER" ]; then
     exit 1
 fi
 
+# Warn about existing data directory
+COLLECTOR_DATA_DIR="/var/lib/better-stack"
+if [ -d "$COLLECTOR_DATA_DIR" ]; then
+    echo "WARNING: $COLLECTOR_DATA_DIR already exists from a previous installation."
+    echo "This is expected during upgrades. If you're fully reinstalling the collector, delete the directory first:"
+    echo "  rm -rf $COLLECTOR_DATA_DIR"
+fi
+
 # Create temporary directory and cd into it
 TEMP_DIR=$(mktemp -d)
 cd "$TEMP_DIR"


### PR DESCRIPTION
- `install.sh` warns on previous /var/lib/better-stack existing
- doesn't _exit_, just warns - hopefully tipping off an attentive user/agent something is not as expected
- bootstrap procedure somewhat hardened for key services:
	- if `updater.rb` is in place, it _should_ figure stuff out
	- if it isn't, we're in incomplete state and it's best to re-bootstrap