### PR TITLE
Use OBI v0.10.0 and align component versions

### DIFF
--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,0 +1,80 @@
+name: Check version sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "collector/Dockerfile"
+      - "ebpf/Dockerfile"
+      - "CLAUDE.md"
+      - ".github/workflows/version-sync.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "collector/Dockerfile"
+      - "ebpf/Dockerfile"
+      - "CLAUDE.md"
+      - ".github/workflows/version-sync.yml"
+
+jobs:
+  version-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify component versions match across Dockerfiles, ENV, and CLAUDE.md
+        run: |
+          set +e
+          fail=0
+          norm() { printf '%s' "$1" | tr -d '"' | sed 's/^v//'; }
+          check() {
+            if [ "$2" != "$3" ]; then
+              echo "::error::$1 mismatch: '$2' != '$3' (source of truth: '$3')"
+              fail=1
+            else
+              echo "✓ $1: $2"
+            fi
+          }
+
+          COL=collector/Dockerfile
+          EBPF=ebpf/Dockerfile
+          DOC=CLAUDE.md
+
+          # Source of truth: the Dockerfile pins that actually get built/pulled.
+          vec=$(grep -oP '^FROM timberio/vector:\K[^- ]+' "$COL" | head -1)
+          obi=$(norm "$(grep -oP '^ARG OBI_VERSION=\K.*' "$EBPF" | head -1)")
+          na=$(norm "$(grep -oP '^ARG NODE_AGENT_VERSION=\K.*' "$EBPF" | head -1)")
+          ca=$(norm "$(grep -oP '^ARG CLUSTER_AGENT_VERSION=\K.*' "$EBPF" | head -1)")
+
+          # collector's reported ENV block must match the pins.
+          check "collector ENV VECTOR_VERSION"        "$(grep -oP '^ENV VECTOR_VERSION=\K.*' "$COL" | head -1)"                   "$vec"
+          check "collector ENV OBI_VERSION"           "$(norm "$(grep -oP '^ENV OBI_VERSION=\K.*' "$COL" | head -1)")"            "$obi"
+          check "collector ENV CLUSTER_AGENT_VERSION" "$(norm "$(grep -oP '^ENV CLUSTER_AGENT_VERSION=\K.*' "$COL" | head -1)")"  "$ca"
+
+          # collector builds the same cluster-agent it declares (and that ebpf ships).
+          check "collector build ARG CLUSTER_AGENT_VERSION" "$(norm "$(grep -oP '^ARG CLUSTER_AGENT_VERSION=\K.*' "$COL" | head -1)")" "$ca"
+
+          # CLAUDE.md summary must match the pins.
+          check "CLAUDE.md Vector"        "$(grep -oP 'Vector \K[0-9][0-9.]*' "$DOC" | head -1)"        "$vec"
+          check "CLAUDE.md OBI"           "$(grep -oP 'OBI \K[0-9][0-9.]*' "$DOC" | head -1)"           "$obi"
+          check "CLAUDE.md Node Agent"    "$(grep -oP 'Node Agent \K[0-9][0-9.]*' "$DOC" | head -1)"    "$na"
+          check "CLAUDE.md Cluster Agent" "$(grep -oP 'Cluster Agent \K[0-9][0-9.]*' "$DOC" | head -1)" "$ca"
+
+          # All debian bases must be one pinned point release, matching CLAUDE.md.
+          deb_pins=$(grep -hoP '^FROM debian:\K[^ ]+' "$COL" "$EBPF" | sed 's/-slim$//' | sort -u)
+          if [ "$(printf '%s\n' "$deb_pins" | grep -c .)" -ne 1 ] || ! printf '%s' "$deb_pins" | grep -qxP '[0-9]+\.[0-9]+'; then
+            echo "::error::Debian bases must be one pinned point release (e.g. 13.5); found: $(echo $deb_pins)"
+            fail=1
+          else
+            doc_deb=$(grep -oP 'Debian \K[0-9][0-9.]*' "$DOC" | sort -u)
+            if [ "$(printf '%s\n' "$doc_deb" | grep -c .)" -ne 1 ]; then
+              echo "::error::CLAUDE.md has inconsistent Debian versions: $(echo $doc_deb)"
+              fail=1
+            else
+              check "Debian (pins vs CLAUDE.md)" "$doc_deb" "$deb_pins"
+            fi
+          fi
+
+          exit $fail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,20 +20,22 @@ docker-compose.yml          # Standard compose: collector + ebpf services
 docker-compose.seccomp.yml  # Same with seccomp for Docker < 20.10.10
 collector-seccomp.json      # Seccomp profile allowing clone3 for Tokio/Vector
 collector/
-  Dockerfile                # Multi-stage: Vector 0.47.0 + Cluster Agent 1.2.4 + Debian 12.11-slim
+  Dockerfile                # Multi-stage: Vector 0.47.0 + Cluster Agent 1.6.1 + Debian 13.5-slim
   bootstrap.sh              # Downloads manifest from API, provisions both containers
   bootstrap_supervisord.conf
   run_supervisord.sh
   versions/0-default/       # Default Vector config + empty databases.json
   kubernetes-discovery/0-default/
 ebpf/
-  Dockerfile                # Multi-stage: OBI 0.4.1 + Node Agent 1.27.0 + exporters + Debian 12.11-slim
+  Dockerfile                # Multi-stage: OBI 0.10.0 + Node Agent 1.30.0 + exporters + Debian 13.5-slim
   bootstrap_supervisord.conf
   run_supervisord.sh
 swarm/
   docker-compose.swarm-collector.yml  # Swarm global service for collector
   docker-compose.swarm-ebpf.yml      # Regular docker-compose for eBPF (needs host network)
 ```
+
+> **These version numbers are duplicated in several places — keep them in sync.** The source of truth is the `FROM`/`ARG` pins in `collector/Dockerfile` and `ebpf/Dockerfile`. When you bump one, also update its `ENV *_VERSION` line in `collector/Dockerfile` (if it has one) and the summary above.
 
 ## Development Commands
 

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,8 +1,21 @@
 # Use Vector as the base image
 FROM timberio/vector:0.47.0-debian AS vector
 
-# Add Cluster Agent to the image
-FROM ghcr.io/coroot/coroot-cluster-agent:1.2.4 AS cluster-agent
+# Build Cluster Agent from source with patches
+FROM debian:13.5 AS cluster-agent-builder
+RUN apt-get update && apt-get install -y curl git
+ARG GO_VERSION=1.24.9
+RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && rm go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+ARG CLUSTER_AGENT_VERSION=v1.6.1
+RUN git clone --depth 1 --branch ${CLUSTER_AGENT_VERSION} \
+    https://github.com/coroot/coroot-cluster-agent.git /tmp/cluster-agent
+WORKDIR /tmp/cluster-agent
+COPY ebpf/patches/cluster-agent/*.patch ./
+RUN git apply *.patch
+RUN CGO_ENABLED=0 go build -mod=readonly \
+    -o /usr/bin/coroot-cluster-agent .
 
 # Final stage
 FROM debian:13.5-slim
@@ -31,7 +44,7 @@ COPY --from=vector --chmod=755 /usr/bin/vector /usr/local/bin/vector
 COPY --from=vector /etc/vector /etc/vector
 
 # Copy Cluster Agent
-COPY --from=cluster-agent --chmod=755 /usr/bin/coroot-cluster-agent /usr/local/bin/cluster-agent
+COPY --from=cluster-agent-builder --chmod=755 /usr/bin/coroot-cluster-agent /usr/local/bin/cluster-agent
 
 # Create necessary directories
 RUN mkdir -p /versions/0-default \
@@ -46,10 +59,10 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.1.27
+ENV COLLECTOR_VERSION=1.1.28
 ENV VECTOR_VERSION=0.47.0
-ENV OBI_VERSION=0.4.1
-ENV CLUSTER_AGENT_VERSION=1.2.4
+ENV OBI_VERSION=0.10.0
+ENV CLUSTER_AGENT_VERSION=1.6.1
 
 # The environment variable TINI_SUBREAPER=true is related to Tini, which is the init system being used in this Docker container.
 # When TINI_SUBREAPER is set to true, it enables Tini's "subreaper" functionality. Here's what that means:

--- a/ebpf/Dockerfile
+++ b/ebpf/Dockerfile
@@ -1,5 +1,5 @@
 # Build Node Agent from source with patches
-FROM debian:trixie AS node-agent-builder
+FROM debian:13.5 AS node-agent-builder
 RUN apt-get update && apt-get install -y \
     curl git build-essential pkg-config libsystemd-dev
 ARG GO_VERSION=1.24.9
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=1 go build -mod=readonly \
     -o /usr/bin/coroot-node-agent .
 
 # Build Cluster Agent from source with patches
-FROM debian:trixie AS cluster-agent-builder
+FROM debian:13.5 AS cluster-agent-builder
 RUN apt-get update && apt-get install -y curl git
 ARG GO_VERSION=1.24.9
 RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz -o go.tar.gz && \
@@ -49,13 +49,13 @@ FROM quay.io/prometheuscommunity/elasticsearch-exporter:v1.10.0 AS elasticsearch
 FROM prometheuscommunity/pgbouncer-exporter:v0.12.0 AS pgbouncer-exporter
 
 # Download OBI binary from GitHub release (Docker image otel/ebpf-instrument:v0.5.0 exists but is amd64-only)
-FROM debian:12.11-slim AS obi-source
+FROM debian:13.5-slim AS obi-source
 ARG TARGETARCH
-ARG OBI_VERSION="v0.7.1"
+ARG OBI_VERSION="v0.10.0"
 ADD https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/${OBI_VERSION}/obi-${OBI_VERSION}-linux-${TARGETARCH}.tar.gz /tmp/obi.tar.gz
 RUN tar -xzf /tmp/obi.tar.gz -C /tmp
 
-# Final stage - Using Debian 12.11-slim for glibc compatibility with node-agent
+# Final stage - Debian slim for glibc compatibility with node-agent
 FROM debian:13.5-slim
 
 # Install supervisor, ca-certificates, curl, procps, and Ruby


### PR DESCRIPTION
Bumps OBI eBPF instrumentation from v0.7.1 to v0.10.0, then fixes version metadata that had drifted from the Dockerfiles and adds CI to keep it honest.

## OBI
- `ebpf/Dockerfile`: OBI v0.7.1 → v0.10.0 (both arch tarballs verified to resolve)
- `collector/Dockerfile`: collector version → 1.1.28

## Cluster-agent drift (real fix)
The collector pulled the **stock** `coroot-cluster-agent:1.2.4` while the ebpf image builds `v1.6.1` from source with the `statement_timeout` DSN patch. In cluster-collector mode the collector's agent does database monitoring, so the stock image could reintroduce the PgBouncer `statement_timeout` rejection the patch fixes.
- `collector/Dockerfile` now builds the cluster-agent from source with the **same patch** as ebpf (v1.6.1); the patch stays a single source of truth in `ebpf/patches/cluster-agent/`.

## Debian bases
All Debian bases are now pinned to **13.5** (trixie):
- obi-source was leftover on bookworm `12.11-slim` (only a tar-extraction stage, but inconsistent) → `13.5-slim`
- the builder stages floated on the `trixie` tag while the final was pinned `13.5-slim`. node-agent is `CGO_ENABLED=1` (glibc-linked), so a floating builder could out-run the pinned final's glibc. Builders (ebpf ×2 + the new collector one) → pinned `debian:13.5`.

## Metadata true-up
- `collector/Dockerfile`: `ENV OBI_VERSION` 0.4.1 → 0.10.0, `CLUSTER_AGENT_VERSION` 1.2.4 → 1.6.1
- `CLAUDE.md`: Node Agent 1.27.0 → 1.30.0, Debian 12.11 → 13.5, Cluster Agent 1.2.4 → 1.6.1; dropped the stale Debian version from the ebpf comment; added a keep-in-sync note

## CI
- `.github/workflows/version-sync.yml` fails when the Dockerfile pins, the collector `ENV *_VERSION` block, and the CLAUDE.md summary disagree — Vector, OBI, Node Agent, Cluster Agent, and a single pinned Debian version across all stages. Verified green on the current tree and red on injected drift (including a reintroduced floating `trixie`).