### PR TITLE
Bump elasticsearch_exporter v1.10.0 -> v1.11.0

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.1.28
+ENV COLLECTOR_VERSION=1.1.29
 ENV VECTOR_VERSION=0.47.0
 ENV OBI_VERSION=0.10.0
 ENV CLUSTER_AGENT_VERSION=1.6.1

--- a/ebpf/Dockerfile
+++ b/ebpf/Dockerfile
@@ -43,7 +43,7 @@ FROM prometheuscommunity/postgres-exporter:v0.18.1 AS postgres-exporter
 FROM danielqsj/kafka-exporter:v1.9.0 AS kafka-exporter
 
 # Add elasticsearch exporter to the image
-FROM quay.io/prometheuscommunity/elasticsearch-exporter:v1.10.0 AS elasticsearch-exporter
+FROM quay.io/prometheuscommunity/elasticsearch-exporter:v1.11.0 AS elasticsearch-exporter
 
 # Add pgbouncer exporter to the image
 FROM prometheuscommunity/pgbouncer-exporter:v0.12.0 AS pgbouncer-exporter


### PR DESCRIPTION
Fixes the idle-connection leak in the exporter's multi-target feature
(prometheus-community/elasticsearch_exporter#1136): v1.10.0 opens ~1
keep-alive socket to Elasticsearch per scrape and never closes it, so
the ebpf container's RSS ratchets up unbounded (observed ~6000
ESTABLISHED conns / 420MB after 24h, resets to a few MB on restart).
v1.11.0 also streams the /_all/_stats decode for ~10x lower peak
memory per scrape (#1159).