### PR TITLE
SH-1002 [CI] Update GitHub Actions versions

### DIFF
--- a/.github/workflows/check-docs-scripts.yml
+++ b/.github/workflows/check-docs-scripts.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: "Verify all scripts linked in https://betterstack.com/docs/logs/collector exist"
         run: |

--- a/.github/workflows/cluster-agent-patch-ci.yml
+++ b/.github/workflows/cluster-agent-patch-ci.yml
@@ -51,6 +51,10 @@ jobs:
 
       - name: goimports -l .
         working-directory: /tmp/cluster-agent
+        env:
+          # setup-go@v6+ exports GOTOOLCHAIN=local; goimports@latest needs a newer
+          # toolchain than the pinned one, so allow the automatic download here.
+          GOTOOLCHAIN: auto
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
           files=$(goimports -l .); if [[ -n "$files" ]]; then echo "$files"; exit 1; fi

--- a/.github/workflows/cluster-agent-patch-ci.yml
+++ b/.github/workflows/cluster-agent-patch-ci.yml
@@ -18,7 +18,7 @@ jobs:
   test-cluster-agent-patch:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Clone cluster-agent and apply patches
         run: |
@@ -28,12 +28,12 @@ jobs:
           cd /tmp/cluster-agent
           git apply ${{ github.workspace }}/ebpf/patches/cluster-agent/*.patch
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.24.9"
           cache: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -68,7 +68,7 @@ jobs:
 
       - name: Set up Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/collector
@@ -82,7 +82,7 @@ jobs:
             type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -122,7 +122,7 @@ jobs:
 
       - name: Set up Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/collector-ebpf
@@ -136,7 +136,7 @@ jobs:
             type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-compose-match.yml
+++ b/.github/workflows/docker-compose-match.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: check diff between docker-compose.yml and docker-compose.seccomp.yml
       run: |

--- a/.github/workflows/node-agent-patch-ci.yml
+++ b/.github/workflows/node-agent-patch-ci.yml
@@ -18,7 +18,7 @@ jobs:
   test-node-agent-patch:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Clone node-agent and apply patches
         run: |
@@ -28,12 +28,12 @@ jobs:
           cd /tmp/node-agent
           git apply ${{ github.workspace }}/ebpf/patches/node-agent/*.patch
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.23.8"
           cache: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/node-agent-patch-ci.yml
+++ b/.github/workflows/node-agent-patch-ci.yml
@@ -33,6 +33,11 @@ jobs:
           go-version: "1.23.8"
           cache: false
 
+      # setup-go@v6+ exports GOTOOLCHAIN=local, but the cloned node-agent's go.mod
+      # (and goimports@latest) require newer toolchains; restore the pre-v6
+      # auto-download behavior for the rest of the job.
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+
       - uses: actions/cache@v6
         with:
           path: |
@@ -54,10 +59,6 @@ jobs:
 
       - name: goimports -l .
         working-directory: /tmp/node-agent
-        env:
-          # setup-go@v6+ exports GOTOOLCHAIN=local; goimports@latest needs a newer
-          # toolchain than the pinned one, so allow the automatic download here.
-          GOTOOLCHAIN: auto
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
           files=$(goimports -l .); if [[ -n "$files" ]]; then echo "$files"; exit 1; fi

--- a/.github/workflows/node-agent-patch-ci.yml
+++ b/.github/workflows/node-agent-patch-ci.yml
@@ -54,6 +54,10 @@ jobs:
 
       - name: goimports -l .
         working-directory: /tmp/node-agent
+        env:
+          # setup-go@v6+ exports GOTOOLCHAIN=local; goimports@latest needs a newer
+          # toolchain than the pinned one, so allow the automatic download here.
+          GOTOOLCHAIN: auto
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
           files=$(goimports -l .); if [[ -n "$files" ]]; then echo "$files"; exit 1; fi

--- a/.github/workflows/obi-patch-ci.yml
+++ b/.github/workflows/obi-patch-ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Read OBI build pins
         run: |
@@ -50,7 +50,7 @@ jobs:
             -w /src \
             "$OBI_GENERATOR"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ runner.temp }}/obi/go.mod
           cache: false

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -22,7 +22,7 @@ jobs:
   version-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Verify component versions match across Dockerfiles, ENV, and CLAUDE.md
         run: |


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions (forced to Node 24 since June 2nd, 2026; Node 20 removed from runners on September 16th, 2026), and Node 12/16 actions are already force-migrated. This bumps the affected actions to their latest majors (all Node 24):

- `actions/checkout` `v3`/`v4` → `v7`
- `actions/setup-go` `v5` → `v7`
- `actions/cache` `v4` → `v6`
- `docker/login-action` `v3` → `v4`
- `docker/metadata-action` `v5` → `v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
