### PR TITLE
Backport OBI sockmap fixes for stalled large proxied responses

### DIFF
--- a/ebpf/patches/obi/003-fionread-sockhash-workaround.patch
+++ b/ebpf/patches/obi/003-fionread-sockhash-workaround.patch
@@ -1,0 +1,542 @@
+diff --git a/Makefile b/Makefile
+index ad11424e4..65c587ccc 100644
+--- a/Makefile
++++ b/Makefile
+@@ -237,7 +237,7 @@ update-offsets:
+ BPF_ROOT = pkg/
+ 
+ # Find all generated Go and object files (used as Make targets)
+-BPF_GEN_GO := $(shell find $(BPF_ROOT) -type f \( -name 'bpf_*_bpfe[lb].go' -o -name 'net_*_bpfe[lb].go' -o -name 'netsk_*_bpfe[lb].go' -o -name 'stats_*_bpfe[lb].go' \))
++BPF_GEN_GO := $(shell find $(BPF_ROOT) -type f \( -name 'bpf*_bpfe[lb].go' -o -name 'net_*_bpfe[lb].go' -o -name 'netsk_*_bpfe[lb].go' -o -name 'stats_*_bpfe[lb].go' \))
+ BPF_GEN_OBJ := $(BPF_GEN_GO:.go=.o)
+ BPF_GEN_ALL := $(if $(BPF_GEN_GO),$(BPF_GEN_GO) $(BPF_GEN_OBJ))
+ 
+diff --git a/bpf/maps/tracked_sock_cookies.h b/bpf/maps/tracked_sock_cookies.h
+new file mode 100644
+index 000000000..71168f069
+--- /dev/null
++++ b/bpf/maps/tracked_sock_cookies.h
+@@ -0,0 +1,28 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++// Context for future maintainers: this code was added to mitigate a bug in the Linux kernel that
++// was fixed a few weeks after being reported (July 2026), but had already reached some users'
++// production environments from version 6.x onwards (via backports). This mitigation code will be
++// kept here for an undetermined, long period of time, until it is safe to assume that no trace of
++// the buggy kernel versions remains.
++// Original report impacting OBI users: https://github.com/grafana/beyla/issues/2941
++// Kernel bug fix and merge notification thread:
++// https://lore.kernel.org/bpf/20260708-fionread-no-verdict-v3-0-b4ee31b3af53@coralogix.com/
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++#include <common/pin_internal.h>
++
++// Cookies of sockets inserted into sock_dir; the FIONREAD fixup uses them
++// to identify affected sockets. LRU so stale entries age out
++struct {
++    __uint(type, BPF_MAP_TYPE_LRU_HASH);
++    __uint(max_entries, 65535);
++    __uint(key_size, sizeof(u64));
++    __uint(value_size, sizeof(u8));
++    __uint(pinning, OBI_PIN_INTERNAL);
++} tracked_sock_cookies SEC(".maps");
+diff --git a/bpf/tpinjector/fionread_fixup.c b/bpf/tpinjector/fionread_fixup.c
+new file mode 100644
+index 000000000..4a845b4a9
+--- /dev/null
++++ b/bpf/tpinjector/fionread_fixup.c
+@@ -0,0 +1,130 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++// Context for future maintainers: this code was added to mitigate a bug in the Linux kernel that
++// was fixed a few weeks after being reported (July 2026), but had already reached some users'
++// production environments from version 6.x onwards (via backports). This mitigation code will be
++// kept here for an undetermined, long period of time, until it is safe to assume that no trace of
++// the buggy kernel versions remains.
++// Original report impacting OBI users: https://github.com/grafana/beyla/issues/2941
++// Kernel bug fix and merge notification thread:
++// https://lore.kernel.org/bpf/20260708-fionread-no-verdict-v3-0-b4ee31b3af53@coralogix.com/
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_core_read.h>
++#include <bpfcore/bpf_helpers.h>
++
++#include <logger/bpf_dbg.h>
++
++#include <maps/tracked_sock_cookies.h>
++
++char __license[] SEC("license") = "Dual MIT/GPL";
++
++// Kernels with commit 929e30f93125 report FIONREAD=0 for sockets in a
++// sockhash without a verdict program; rewrite the user-visible result with
++// the real queue length (tcp_inq) after the kernel's put_user
++enum { k_fionread = 0x541B };
++
++typedef struct fionread_fix {
++    u64 arg;
++    struct sock *sk;
++} fionread_fix_t;
++
++struct {
++    __uint(type, BPF_MAP_TYPE_LRU_HASH);
++    __uint(max_entries, 10240);
++    __uint(key_size, sizeof(u64));
++    __uint(value_size, sizeof(fionread_fix_t));
++} fionread_inflight SEC(".maps");
++
++SEC("tracepoint/syscalls/sys_enter_ioctl")
++int obi_fionread_fixup_enter(struct trace_event_raw_sys_enter *ctx) {
++    if ((u32)ctx->args[1] != k_fionread) {
++        return 0;
++    }
++
++    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
++    struct fdtable *fdt = BPF_CORE_READ(task, files, fdt);
++    const u32 fd = (u32)ctx->args[0];
++
++    if (fd >= BPF_CORE_READ(fdt, max_fds)) {
++        return 0;
++    }
++
++    struct file **fd_arr = BPF_CORE_READ(fdt, fd);
++    struct file *file = NULL;
++    bpf_probe_read_kernel(&file, sizeof(file), fd_arr + fd);
++
++    if (!file) {
++        return 0;
++    }
++
++    struct socket *sock = BPF_CORE_READ(file, private_data);
++    if (!sock) {
++        return 0;
++    }
++
++    struct sock *sk = BPF_CORE_READ(sock, sk);
++    if (!sk) {
++        return 0;
++    }
++
++    // a non-socket file's private_data cannot yield a tracked cookie
++    const u64 cookie = BPF_CORE_READ(sk, __sk_common.skc_cookie.counter);
++
++    if (!bpf_map_lookup_elem(&tracked_sock_cookies, &cookie)) {
++        return 0;
++    }
++
++    const u64 id = bpf_get_current_pid_tgid();
++    fionread_fix_t fix = {.arg = ctx->args[2], .sk = sk};
++    bpf_map_update_elem(&fionread_inflight, &id, &fix, BPF_ANY);
++
++    return 0;
++}
++
++SEC("tracepoint/syscalls/sys_exit_ioctl")
++int obi_fionread_fixup_exit(struct trace_event_raw_sys_exit *ctx) {
++    const u64 id = bpf_get_current_pid_tgid();
++    const fionread_fix_t *fix = bpf_map_lookup_elem(&fionread_inflight, &id);
++
++    if (!fix) {
++        return 0;
++    }
++
++    struct sock *sk = fix->sk;
++    void *arg = (void *)fix->arg;
++
++    bpf_map_delete_elem(&fionread_inflight, &id);
++
++    if (ctx->ret != 0) {
++        return 0;
++    }
++
++    // mirrors tcp_inq(); the fd is held for the whole syscall so sk is live
++    const u8 state = BPF_CORE_READ(sk, __sk_common.skc_state);
++
++    if (state == TCP_SYN_SENT || state == TCP_SYN_RECV) {
++        return 0;
++    }
++
++    struct tcp_sock *tp = (struct tcp_sock *)sk;
++    const u32 rcv_nxt = BPF_CORE_READ(tp, rcv_nxt);
++    const u32 copied_seq = BPF_CORE_READ(tp, copied_seq);
++    int inq = (int)(rcv_nxt - copied_seq);
++
++    const unsigned long flags = BPF_CORE_READ(sk, __sk_common.skc_flags);
++
++    if (inq > 0 && (flags & (1UL << SOCK_DONE))) {
++        inq--;
++    }
++
++    if (inq < 0) {
++        inq = 0;
++    }
++
++    const long err = bpf_probe_write_user(arg, &inq, sizeof(inq));
++    bpf_dbg_printk("fionread fix inq=%d err=%ld", inq, err);
++
++    return 0;
++}
+diff --git a/bpf/tpinjector/sock_iter.c b/bpf/tpinjector/sock_iter.c
+index 2fa92433a..74cf07c4e 100644
+--- a/bpf/tpinjector/sock_iter.c
++++ b/bpf/tpinjector/sock_iter.c
+@@ -11,6 +11,7 @@
+ #include <logger/bpf_dbg.h>
+ 
+ #include <maps/sock_dir.h>
++#include <maps/tracked_sock_cookies.h>
+ 
+ char __license[] SEC("license") = "Dual MIT/GPL";
+ 
+@@ -105,6 +106,8 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
+ 
+     if (bpf_map_update_elem(&sock_dir, &cookie, skc, BPF_NOEXIST) != 0) {
+         bpf_dbg_printk("Failed to track sock cookie=%llu", cookie);
++    } else {
++        bpf_map_update_elem(&tracked_sock_cookies, &cookie, &(u8){1}, BPF_ANY);
+     }
+ 
+     return 0;
+diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
+index 014cd3842..66d27991e 100644
+--- a/bpf/tpinjector/tpinjector.c
++++ b/bpf/tpinjector/tpinjector.c
+@@ -37,6 +37,7 @@
+ #include <maps/outgoing_trace_map.h>
+ #include <maps/sock_dir.h>
+ #include <maps/tp_info_mem.h>
++#include <maps/tracked_sock_cookies.h>
+ 
+ #include <tpinjector/h2_parse.h>
+ #include <tpinjector/maps/sk_h2_conn_flag.h>
+@@ -393,7 +394,9 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
+ static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skops) {
+     const u64 cookie = bpf_get_socket_cookie(skops);
+ 
+-    bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY);
++    if (bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY) == 0) {
++        bpf_map_update_elem(&tracked_sock_cookies, &cookie, &(u8){1}, BPF_ANY);
++    }
+     bpf_sock_ops_set_flags(skops, BPF_SOCK_OPS_WRITE_HDR_OPT_CB_FLAG);
+ }
+ 
+diff --git a/pkg/ebpf/instrumenter.go b/pkg/ebpf/instrumenter.go
+index 54215bf5f..c0d287481 100644
+--- a/pkg/ebpf/instrumenter.go
++++ b/pkg/ebpf/instrumenter.go
+@@ -749,10 +749,14 @@ func (i *instrumenter) tracepoints(p KprobesTracer) error {
+ 		slog.Debug("going to add syscall", "function", sfunc, "probes", sprobes)
+ 
+ 		if err := i.tracepoint(sfunc, sprobes); err != nil {
+-			if i.metrics != nil {
+-				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorInvalidTracepoint)
++			if sprobes.Required {
++				if i.metrics != nil {
++					i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorInvalidTracepoint)
++				}
++				return fmt.Errorf("instrumenting function %q: %w", sfunc, err)
+ 			}
+-			return fmt.Errorf("instrumenting function %q: %w", sfunc, err)
++
++			slog.Debug("error instrumenting tracepoint", "function", sfunc, "error", err)
+ 		}
+ 		p.AddCloser(i.closables...)
+ 	}
+diff --git a/pkg/internal/ebpf/tpinjector/fionread_check.go b/pkg/internal/ebpf/tpinjector/fionread_check.go
+new file mode 100644
+index 000000000..83d6b7a9e
+--- /dev/null
++++ b/pkg/internal/ebpf/tpinjector/fionread_check.go
+@@ -0,0 +1,169 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++//go:build linux
++
++package tpinjector // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tpinjector"
++
++// Context for future maintainers: this code was added to mitigate a bug in the Linux kernel that
++// was fixed a few weeks after being reported (July 2026), but had already reached some users'
++// production environments from version 6.x onwards (via backports). This mitigation code will be
++// kept here for an undetermined, long period of time, until it is safe to assume that no trace of
++// the buggy kernel versions remains.
++// Original report impacting OBI users: https://github.com/grafana/beyla/issues/2941
++// Kernel bug fix and merge notification thread:
++// https://lore.kernel.org/bpf/20260708-fionread-no-verdict-v3-0-b4ee31b3af53@coralogix.com/
++
++import (
++	"errors"
++	"fmt"
++	"net"
++	"time"
++
++	"github.com/cilium/ebpf"
++	"golang.org/x/sys/unix"
++
++	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
++)
++
++// Detects kernels where sockhash insertion breaks FIONREAD (commit
++// 929e30f93125). cookies non-nil: register the probe socket so an attached
++// fixup applies and the corrected behavior is measured
++func sockhashFIONREADProbe(cookies *ebpf.Map) (bool, error) {
++	sockHash, err := ebpf.NewMap(&ebpf.MapSpec{
++		Name:       "obi_fionread_p",
++		Type:       ebpf.SockHash,
++		KeySize:    8,
++		ValueSize:  4,
++		MaxEntries: 2,
++	})
++	if err != nil {
++		return false, fmt.Errorf("creating probe sockhash: %w", err)
++	}
++	defer sockHash.Close()
++
++	lsn, err := net.Listen("tcp", "127.0.0.1:0")
++	if err != nil {
++		return false, fmt.Errorf("listening on loopback: %w", err)
++	}
++	defer lsn.Close()
++
++	client, err := net.Dial("tcp", lsn.Addr().String())
++	if err != nil {
++		return false, fmt.Errorf("connecting to probe listener: %w", err)
++	}
++	defer client.Close()
++
++	server, err := lsn.Accept()
++	if err != nil {
++		return false, fmt.Errorf("accepting probe connection: %w", err)
++	}
++	defer server.Close()
++
++	raw, err := client.(*net.TCPConn).SyscallConn()
++	if err != nil {
++		return false, fmt.Errorf("getting raw conn: %w", err)
++	}
++	var fd int
++	if err := raw.Control(func(f uintptr) { fd = int(f) }); err != nil {
++		return false, fmt.Errorf("getting socket fd: %w", err)
++	}
++
++	key := uint64(1)
++	if err := sockHash.Update(&key, uint32(fd), ebpf.UpdateAny); err != nil {
++		return false, fmt.Errorf("inserting socket into probe sockhash: %w", err)
++	}
++
++	if cookies != nil {
++		cookie, err := unix.GetsockoptUint64(fd, unix.SOL_SOCKET, unix.SO_COOKIE)
++		if err != nil {
++			return false, fmt.Errorf("getting socket cookie: %w", err)
++		}
++		if err := cookies.Update(&cookie, uint8(1), ebpf.UpdateAny); err != nil {
++			return false, fmt.Errorf("registering probe cookie: %w", err)
++		}
++		defer cookies.Delete(&cookie) //nolint:errcheck
++	}
++
++	const payload = 4096
++	if _, err := server.Write(make([]byte, payload)); err != nil {
++		return false, fmt.Errorf("writing probe payload: %w", err)
++	}
++
++	// FIONREAD itself is under test, so readiness must come from MSG_PEEK
++	buf := make([]byte, payload)
++	deadline := time.Now().Add(2 * time.Second)
++	for {
++		n, _, err := unix.Recvfrom(fd, buf, unix.MSG_PEEK|unix.MSG_DONTWAIT)
++		if err == nil && n == payload {
++			break
++		}
++		if time.Now().After(deadline) {
++			return false, errors.New("probe payload never became readable")
++		}
++		time.Sleep(5 * time.Millisecond)
++	}
++
++	// TIOCINQ == FIONREAD on Linux; x/sys/unix lacks a FIONREAD alias
++	avail, err := unix.IoctlGetInt(fd, unix.TIOCINQ)
++	if err != nil {
++		return false, fmt.Errorf("ioctl(FIONREAD): %w", err)
++	}
++
++	return avail != payload, nil
++}
++
++func (p *Tracer) kernelBreaksFIONREAD() bool {
++	p.fionreadOnce.Do(func() {
++		broken, err := sockhashFIONREADProbe(nil)
++		if err != nil {
++			p.log.Warn("FIONREAD sockhash probe failed", "error", err)
++			return
++		}
++		p.fionreadBroken = broken
++		if broken {
++			p.log.Warn("kernel misreports ioctl(FIONREAD) for sockets in a sockhash " +
++				"(kernel commit 929e30f93125, present in 6.6.128+, 6.12.75+, 6.18.14+ and 6.19+); " +
++				"enabling BPF compensation for tracked sockets")
++		}
++	})
++	return p.fionreadBroken
++}
++
++// test-load on a throwaway copy so LoadSpecs can skip the bundle on kernels
++// that reject bpf_probe_write_user (lockdown)
++func loadableFIONREADFixup() (*ebpf.CollectionSpec, error) {
++	spec, err := LoadBpfFionreadFixup()
++	if err != nil {
++		return nil, err
++	}
++	test := spec.Copy()
++	for _, m := range test.Maps {
++		if m.Pinning == ebpfconvenience.PinInternal {
++			m.Pinning = ebpf.PinNone
++		}
++	}
++	coll, err := ebpf.NewCollection(test)
++	if err != nil {
++		return nil, err
++	}
++	coll.Close()
++	return spec, nil
++}
++
++// end-to-end check that the attached fixup actually corrects FIONREAD
++func (p *Tracer) verifyFIONREADFix() {
++	stillBroken, err := sockhashFIONREADProbe(p.bpfObjects.TrackedSockCookies)
++	if err != nil {
++		p.log.Warn("cannot verify FIONREAD compensation", "error", err)
++		return
++	}
++	if stillBroken {
++		p.log.Error("FIONREAD compensation is ineffective (attach failed or blocked?); " +
++			"applications sizing reads via FIONREAD (nginx, Java, .NET) may stall or " +
++			"truncate transfers; set context_propagation: disabled " +
++			"(OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) to avoid impact")
++		return
++	}
++	p.log.Info("FIONREAD compensation verified")
++}
+diff --git a/pkg/internal/ebpf/tpinjector/tpinjector.go b/pkg/internal/ebpf/tpinjector/tpinjector.go
+index 61ada3f3d..5a677e47f 100644
+--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
++++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
+@@ -9,6 +9,7 @@ import (
+ 	"context"
+ 	"io"
+ 	"log/slog"
++	"sync"
+ 
+ 	"github.com/cilium/ebpf"
+ 
+@@ -23,14 +24,19 @@ import (
+ 
+ //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 Bpf ../../../../bpf/tpinjector/tpinjector.c -- -I../../../../bpf -I../../../../bpf
+ //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 BpfIter ../../../../bpf/tpinjector/sock_iter.c -- -I../../../../bpf -I../../../../bpf
++//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 BpfFionreadFixup ../../../../bpf/tpinjector/fionread_fixup.c -- -I../../../../bpf -I../../../../bpf
+ 
+ type Tracer struct {
+-	cfg            *obi.Config
+-	bpfObjects     BpfObjects
+-	bpfIterObjects BpfIterObjects
+-	closers        []io.Closer
+-	log            *slog.Logger
+-	iters          []*ebpfcommon.Iter
++	cfg                     *obi.Config
++	bpfObjects              BpfObjects
++	bpfIterObjects          BpfIterObjects
++	bpfFionreadFixupObjects BpfFionreadFixupObjects
++	closers                 []io.Closer
++	log                     *slog.Logger
++	iters                   []*ebpfcommon.Iter
++	fionreadOnce            sync.Once
++	fionreadBroken          bool
++	fionreadFixupEnabled    bool
+ }
+ 
+ func New(cfg *obi.Config) *Tracer {
+@@ -75,6 +81,25 @@ func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
+ 		})
+ 	}
+ 
++	// kernel lockdown rejects bpf_probe_write_user at load time
++	if p.kernelBreaksFIONREAD() {
++		fixupSpec, err := loadableFIONREADFixup()
++		if err != nil {
++			p.log.Error("kernel misreports FIONREAD for sockets in a sockhash and the BPF "+
++				"compensation cannot be loaded (kernel lockdown?); applications sizing reads "+
++				"via FIONREAD (nginx, Java, .NET) may stall or truncate transfers; "+
++				"set context_propagation: disabled (OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) "+
++				"to avoid impact", "error", err)
++		} else {
++			bundles = append(bundles, &ebpfcommon.SpecBundle{
++				Spec:      fixupSpec,
++				Objects:   &p.bpfFionreadFixupObjects,
++				Constants: map[string]any{"g_bpf_debug": p.cfg.EBPF.BpfDebug},
++			})
++			p.fionreadFixupEnabled = true
++		}
++	}
++
+ 	return bundles, nil
+ }
+ 
+@@ -124,8 +149,16 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
+ 	return nil
+ }
+ 
++// Tracepoints returns the FIONREAD fixup probes; not Required so a failed
++// attach cannot drop the tracer
+ func (p *Tracer) Tracepoints() map[string]ebpfcommon.ProbeDesc {
+-	return nil
++	if !p.fionreadFixupEnabled {
++		return nil
++	}
++	return map[string]ebpfcommon.ProbeDesc{
++		"syscalls/sys_enter_ioctl": {Start: p.bpfFionreadFixupObjects.ObiFionreadFixupEnter},
++		"syscalls/sys_exit_ioctl":  {Start: p.bpfFionreadFixupObjects.ObiFionreadFixupExit},
++	}
+ }
+ 
+ func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
+@@ -196,6 +229,10 @@ func (p *Tracer) AlreadyInstrumentedLib(uint64) bool {
+ func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
+ 	p.log.Debug("tpinjector started")
+ 
++	if p.fionreadFixupEnabled {
++		p.verifyFIONREADFix()
++	}
++
+ 	for _, it := range p.Iters() {
+ 		if err := it.Run(p.log); err != nil {
+ 			p.log.Error("error running iterator", "error", err)
+@@ -206,6 +243,7 @@ func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg
+ 
+ 	p.bpfObjects.Close()
+ 	p.bpfIterObjects.Close()
++	p.bpfFionreadFixupObjects.Close()
+ 
+ 	p.log.Debug("tpinjector terminated")
+ }
+diff --git a/pkg/internal/ebpf/verifier/bpf_verifier_test.go b/pkg/internal/ebpf/verifier/bpf_verifier_test.go
+index 86d15ed0a..7b065d7e5 100644
+--- a/pkg/internal/ebpf/verifier/bpf_verifier_test.go
++++ b/pkg/internal/ebpf/verifier/bpf_verifier_test.go
+@@ -218,6 +218,12 @@ func TestBPFVerifierWithConstants(t *testing.T) {
+ 		t.Logf("skipping tpinjector/BpfIter: kernel %d.%d < 5.11", major, minor)
+ 	}
+ 
++	// tpinjector/BpfFionreadFixup uses bpf_probe_write_user, rejected at load time
++	// under kernel lockdown - none of the CI kernels run locked down
++	forEachCombination(t, "tpinjector/BpfFionreadFixup", tpinjectorbpf.LoadBpfFionreadFixup, []constOption{
++		{"g_bpf_debug", []any{true, false}},
++	})
++
+ 	// watcher
+ 	forEachCombination(t, "watcher/Bpf", watcherbpf.LoadBpf, []constOption{
+ 		{"g_bpf_debug", []any{true, false}},

--- a/ebpf/patches/obi/004-limit-sock-iter-to-active-connections.patch
+++ b/ebpf/patches/obi/004-limit-sock-iter-to-active-connections.patch
@@ -1,0 +1,125 @@
+diff --git a/bpf/tpinjector/maps/iter_listening_ports.h b/bpf/tpinjector/maps/iter_listening_ports.h
+new file mode 100644
+index 000000000..8706f3d09
+--- /dev/null
++++ b/bpf/tpinjector/maps/iter_listening_ports.h
+@@ -0,0 +1,19 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++#include <common/map_sizing.h>
++#include <common/sock_port_ns.h>
++
++// A duplicate map for listening ports, to ensure the tcp_iter and sock_iter
++// can operate independently.
++struct {
++    __uint(type, BPF_MAP_TYPE_LRU_HASH);
++    __type(key, struct sock_port_ns);
++    __type(value, bool);
++    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
++} iter_listening_ports SEC(".maps");
+diff --git a/bpf/tpinjector/sock_iter.c b/bpf/tpinjector/sock_iter.c
+index 74cf07c4e..558559796 100644
+--- a/bpf/tpinjector/sock_iter.c
++++ b/bpf/tpinjector/sock_iter.c
+@@ -7,12 +7,15 @@
+ #include <bpfcore/bpf_endian.h>
+ 
+ #include <common/protocol_defs.h>
++#include <common/sock_port_ns.h>
+ 
+ #include <logger/bpf_dbg.h>
+ 
+ #include <maps/sock_dir.h>
+ #include <maps/tracked_sock_cookies.h>
+ 
++#include <tpinjector/maps/iter_listening_ports.h>
++
+ char __license[] SEC("license") = "Dual MIT/GPL";
+ 
+ // max IPv6+port: "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535" = 48 chars
+@@ -83,6 +86,31 @@ static __always_inline void format_sock_addrs(struct sock_common *skc,
+     }
+ }
+ 
++// First pass, we record every local listening port into iter_listening_ports.
++SEC("iter/tcp")
++int obi_sk_iter_tcp_listen(struct bpf_iter__tcp *ctx) {
++    struct sock_common *skc = ctx->sk_common;
++
++    if (!skc) {
++        return 0;
++    }
++
++    u8 skc_state = BPF_CORE_READ(skc, skc_state);
++
++    if (skc_state != TCP_LISTEN) {
++        return 0;
++    }
++
++    struct sock_port_ns pn = sock_port_ns_from_skc(skc);
++    bpf_map_update_elem(&iter_listening_ports, &pn, &(bool){true}, BPF_ANY);
++
++    struct seq_file *seq = ctx->meta->seq;
++    BPF_SEQ_PRINTF(seq, "Listening port=%u netns=%u\n", pn.port, pn.netns);
++
++    return 0;
++}
++
++// Second pass, track only active client connections in sock_dir.
+ SEC("iter/tcp")
+ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
+     struct sock_common *skc = ctx->sk_common;
+@@ -91,6 +119,19 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
+         return 0;
+     }
+ 
++    // don't look at sockets that aren't established
++    u8 skc_state = BPF_CORE_READ(skc, skc_state);
++    if (skc_state != TCP_ESTABLISHED) {
++        return 0;
++    }
++
++    // skip passive sockets, their local port is a listening port we
++    // found in the prior pass
++    struct sock_port_ns pn = sock_port_ns_from_skc(skc);
++    if (bpf_map_lookup_elem(&iter_listening_ports, &pn) != 0) {
++        return 0;
++    }
++
+     const u64 cookie = bpf_get_socket_cookie(skc);
+ 
+     char src_buf[k_addr_buf_len] = {};
+@@ -102,8 +143,6 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
+ 
+     BPF_SEQ_PRINTF(seq, "Tracking socket cookie=%llu src=%s dst=%s\n", cookie, src_buf, dst_buf);
+ 
+-    bpf_d_printk("Tracking socket cookie=%llu src=%s dst=%s", cookie, src_buf, dst_buf);
+-
+     if (bpf_map_update_elem(&sock_dir, &cookie, skc, BPF_NOEXIST) != 0) {
+         bpf_dbg_printk("Failed to track sock cookie=%llu", cookie);
+     } else {
+diff --git a/pkg/internal/ebpf/tpinjector/tpinjector.go b/pkg/internal/ebpf/tpinjector/tpinjector.go
+index 5a677e47f..2ac375f78 100644
+--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
++++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
+@@ -207,7 +207,13 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
+ 		return p.iters
+ 	}
+ 
+-	p.iters = []*ebpfcommon.Iter{{Program: p.bpfIterObjects.ObiSkIterTcp}}
++	// The ordering matters, we don't want to add passive listeners to
++	// the map, so we first find the listening ports and then we discard
++	// the established with those listening ports.
++	p.iters = []*ebpfcommon.Iter{
++		{Program: p.bpfIterObjects.ObiSkIterTcpListen},
++		{Program: p.bpfIterObjects.ObiSkIterTcp},
++	}
+ 
+ 	return p.iters
+ }

--- a/ebpf/patches/obi/005-h2-genuine-traffic-guard.patch
+++ b/ebpf/patches/obi/005-h2-genuine-traffic-guard.patch
@@ -1,0 +1,206 @@
+diff --git a/bpf/common/h2_defs.h b/bpf/common/h2_defs.h
+index efc802b8f..b51591ac8 100644
+--- a/bpf/common/h2_defs.h
++++ b/bpf/common/h2_defs.h
+@@ -11,6 +11,7 @@ enum {
+     // --- HTTP/2 framing ---
+     k_h2_frame_header_len = 9,
+     k_h2_frame_headers = 1,
++    k_h2_frame_settings = 4, // RFC 7540 §6.5 SETTINGS frame type
+     k_h2_flag_end_headers = 4,
+     k_h2_flag_padded = 8,
+     k_h2_flag_priority = 0x20,
+diff --git a/bpf/tpinjector/h2_parse.h b/bpf/tpinjector/h2_parse.h
+index 5de1d267e..3b53399c3 100644
+--- a/bpf/tpinjector/h2_parse.h
++++ b/bpf/tpinjector/h2_parse.h
+@@ -17,7 +17,8 @@ typedef struct {
+     u32 hpack_offset_in_msg; // start of HPACK bytes inside the sk_msg
+     u32 hpack_len;           // HPACK block length
+     bool is_headers_end;     // true for HEADERS with END_HEADERS, payload_len > 0
+-    u8 _pad[3];
++    u8 ftype;                // raw HTTP/2 frame type byte
++    u8 _pad[2];
+ } h2_frame_info_t;
+ 
+ // Parses the HTTP/2 frame header at `pos` inside `msg` and fills `out`.
+@@ -49,6 +50,7 @@ parse_h2_frame_at(struct sk_msg_md *msg, u32 pos, u32 msg_size, h2_frame_info_t
+     }
+ 
+     out->payload_len = len;
++    out->ftype = ftype;
+     out->is_headers_end =
+         (ftype == k_h2_frame_headers) && (flags & k_h2_flag_end_headers) && (len > 0);
+ 
+diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
+index 66d27991e..f429b7e5e 100644
+--- a/bpf/tpinjector/tpinjector.c
++++ b/bpf/tpinjector/tpinjector.c
+@@ -63,8 +63,8 @@ char __license[] SEC("license") = "Dual MIT/GPL";
+ //   │                                  │
+ //   ├── pull_data + fill_msg_buffers   │  Committed to processing
+ //   │                                  │
+-//   ├── is_h2_socket?                  │  Known plaintext H2: skip preface
+-//   │     └─ tail-call detect_h2       │  check, go straight to HPACK chain
++//   ├── is_h2_socket?                  │  Preface seen / confirmed H2: skip
++//   │     └─ tail-call detect_h2       │  preface check, drive the H2 chain
+ //   │                                 │
+ //   ├── HTTP/1 detected?              │  ── find_existing_tp ── create_tp ──
+ //   │                                 │     write_msg_traceparent
+@@ -74,10 +74,14 @@ char __license[] SEC("license") = "Dual MIT/GPL";
+ //                                           ▼
+ //                                        detect_h2 ◀──────────────┐
+ //                                           │                     │
+-//                                           │ HEADERS+END_HEADERS │ resume on
+-//                                           ▼                     │ batched
+-//                                        find_existing_h2_tp ─────┤ frame via
+-//                                           │ adopt or            │ h2_scan_pos
++//                                           │ preface→SETTINGS     │ resume on
++//                                           │ confirms genuine H2  │ batched
++//                                           │ (else reject);       │ frame via
++//                                           │ then HEADERS+        │ h2_scan_pos
++//                                           │ END_HEADERS          │
++//                                           ▼                     │
++//                                        find_existing_h2_tp ─────┤
++//                                           │ adopt or            │
+ //                                           ▼                     │
+ //                                        create_h2_tp ────────────┤
+ //                                           │                     │
+@@ -171,21 +175,49 @@ h2_resume_after(struct sk_msg_md *msg, tailcall_ctx *t_ctx, u32 next_pos) {
+     bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
+ }
+ 
+-static __always_inline bool is_h2_socket(struct sk_msg_md *msg) {
++// Per-socket HTTP/2 detection state (sk_h2_conn_flag values).
++//
++// We only splice an HPACK traceparent once we've confirmed a *genuine* HTTP/2
++// stream. RFC 7540 §3.4/§3.5 require the client connection preface
++// ("PRI * HTTP/2.0...") to be immediately followed by a SETTINGS frame. A stream
++// that merely embeds the preface inside some other framing — e.g. GitLab
++// Gitaly's yamux-multiplexed backchannel (issue #2706) — never emits that
++// SETTINGS frame as the next bytes on the raw socket; instead the peer's framing
++// header follows. Injecting into such a stream shifts the outer framing and
++// corrupts the connection, so those sockets must be rejected.
++enum {
++    k_h2_sock_none = 0,      // nothing seen yet
++    k_h2_sock_preface = 1,   // preface seen, awaiting the mandatory SETTINGS frame
++    k_h2_sock_confirmed = 2, // SETTINGS seen after preface — genuine HTTP/2, inject
++    k_h2_sock_rejected = 3,  // post-preface bytes were not SETTINGS — never inject
++};
++
++static __always_inline u8 h2_sock_state(struct sk_msg_md *msg) {
+     struct bpf_sock *sk = msg->sk;
+     if (!sk) {
+-        return false;
++        return k_h2_sock_none;
+     }
+     const u8 *flag = bpf_sk_storage_get(&sk_h2_conn_flag, sk, NULL, 0);
+-    return flag && *flag;
++    return flag ? *flag : k_h2_sock_none;
+ }
+ 
+-static __always_inline void mark_h2_socket(struct sk_msg_md *msg) {
++static __always_inline void set_h2_sock_state(struct sk_msg_md *msg, u8 state) {
+     struct bpf_sock *sk = msg->sk;
+     if (!sk) {
+         return;
+     }
+-    bpf_sk_storage_get(&sk_h2_conn_flag, sk, &(u8){1}, BPF_SK_STORAGE_GET_F_CREATE);
++    u8 *flag = bpf_sk_storage_get(&sk_h2_conn_flag, sk, &state, BPF_SK_STORAGE_GET_F_CREATE);
++    if (flag) {
++        *flag = state;
++    }
++}
++
++// True while the socket is in an HTTP/2 scanning state (preface seen or
++// confirmed) — i.e. detect_h2 should keep driving its state machine. Rejected
++// and never-seen sockets are excluded.
++static __always_inline bool is_h2_socket(struct sk_msg_md *msg) {
++    const u8 state = h2_sock_state(msg);
++    return state == k_h2_sock_preface || state == k_h2_sock_confirmed;
+ }
+ 
+ #ifndef ENOMSG
+@@ -840,6 +872,12 @@ static __always_inline void wrap_http2_traceparent(struct sk_msg_md *msg,
+     if (msg->size < k_h2_frame_header_len) {
+         return;
+     }
++    // A socket previously classified as non-HTTP/2 (e.g. a yamux-tunneled
++    // stream) must never be injected into, regardless of what the generic
++    // tracer thinks.
++    if (h2_sock_state(msg) == k_h2_sock_rejected) {
++        return;
++    }
+     if (is_h2_socket(msg) || already_tracked_plain_http2(p_conn)) {
+         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
+         return;
+@@ -1180,16 +1218,26 @@ int obi_packet_extender_detect_h2(struct sk_msg_md *msg) {
+ 
+     u32 pos = t_ctx->h2_scan_pos;
+ 
+-    // Only check preface on the first call (scan_pos == 0). Go gRPC sends
+-    // the 24-byte preface in its own packet, before any HEADERS frame
+-    if (pos == 0 && msg_size >= k_h2_preface_check_len) {
++    u8 state = h2_sock_state(msg);
++    if (state == k_h2_sock_rejected) {
++        return SK_PASS;
++    }
++
++    // Only check the preface on the first scan of a packet (scan_pos == 0) and
++    // only before we've classified the socket. Go gRPC sends the 24-byte
++    // preface in its own packet, before any HEADERS frame.
++    if (pos == 0 && state == k_h2_sock_none && msg_size >= k_h2_preface_check_len) {
+         if (bpf_msg_pull_data(msg, 0, k_h2_preface_check_len, 0) == 0) {
+             if (is_http2_preface(msg->data, msg->data_end)) {
+-                mark_h2_socket(msg);
++                // Preface seen, but NOT yet genuine HTTP/2: RFC 7540 §3.5
++                // requires a SETTINGS frame to follow. We confirm that below
++                // (possibly on the next packet) before ever injecting.
++                state = k_h2_sock_preface;
++                set_h2_sock_state(msg, k_h2_sock_preface);
+                 if (msg_size >= k_h2_preface_len + k_h2_frame_header_len) {
+-                    pos = k_h2_preface_len;
++                    pos = k_h2_preface_len; // SETTINGS may be coalesced here
+                 } else {
+-                    return SK_PASS;
++                    return SK_PASS; // preface-only packet; SETTINGS comes next
+                 }
+             }
+         }
+@@ -1199,6 +1247,36 @@ int obi_packet_extender_detect_h2(struct sk_msg_md *msg) {
+         return SK_PASS;
+     }
+ 
++    // Awaiting the mandatory post-preface SETTINGS frame. If the next frame on
++    // the raw socket is not SETTINGS, the "preface" was just payload of some
++    // other protocol multiplexed over this connection (e.g. Gitaly's yamux
++    // backchannel, GitHub issue #2706). Reject the socket so we never splice HPACK
++    // into it — doing so would shift the outer framing and corrupt the stream.
++    if (state == k_h2_sock_preface) {
++        h2_frame_info_t sf;
++        if (!parse_h2_frame_at(msg, pos, msg_size, &sf)) {
++            // Not enough bytes to decide yet; wait for the next packet without
++            // committing to confirmed or rejected.
++            return SK_PASS;
++        }
++        if (sf.ftype != k_h2_frame_settings) {
++            set_h2_sock_state(msg, k_h2_sock_rejected);
++            return SK_PASS;
++        }
++        set_h2_sock_state(msg, k_h2_sock_confirmed);
++        state = k_h2_sock_confirmed;
++        // Continue after the SETTINGS frame in case HEADERS were coalesced.
++        pos += k_h2_frame_header_len + sf.payload_len;
++        if (msg_size < k_h2_frame_header_len || pos >= msg_size) {
++            return SK_PASS;
++        }
++    }
++
++    // Only a confirmed genuine-HTTP/2 socket may be injected into.
++    if (state != k_h2_sock_confirmed) {
++        return SK_PASS;
++    }
++
+     // Scan up to 4 frames for HEADERS+END_HEADERS
+     for (u8 i = 0; i < k_h2_max_frame_scan; i++) {
+         h2_frame_info_t f;


### PR DESCRIPTION
## Problem

With `context_propagation` enabled (`headers` or `all`), OBI v0.10.0 tracks sockets in a sockhash (`sock_dir`): every outbound connection via sockops, plus — at agent start — every established TCP socket on the host via the `iter/tcp` sweep.

Sockhash membership alone rewires the socket's proto ops. On kernels carrying **bpf, sockmap: Fix FIONREAD for sockmap** (torvalds/linux `929e30f93125`, in 6.6.128+/6.12.75+ and distro backports, including Ubuntu kernels), `ioctl(FIONREAD)` on such sockets reports only the psock ingress queue — always **0** for OBI's TX-only verdict, regardless of how much data sits in the receive queue.

Applications that size reads via FIONREAD (nginx ≥ 1.17.5, Java, .NET) then stop reading: with edge-triggered epoll the readable event never refires, so large proxied responses hang with a frozen Recv-Q or arrive truncated. Stopping the eBPF agent tears down the sockhash and instantly restores normal behavior. Injection mode is irrelevant — the breakage requires no injection at all, so `headers`-only configurations are equally affected.

## Fix

Backport three upstream OBI commits onto the v0.10.0 pin via the existing `ebpf/patches/obi/` mechanism (applied before BPF regeneration in the `obi-builder` stage):

| Patch | Upstream | What it does |
|---|---|---|
| `003-fionread-sockhash-workaround.patch` | [#2580](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2580) + comments from [#2674](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2674) | Runtime probe detects kernels with broken FIONREAD-in-sockhash and compensates by rewriting the ioctl result via syscall tracepoints for tracked sockets. Self-verifying at startup; degrades gracefully (with a loud log) where `bpf_probe_write_user` is blocked. |
| `004-limit-sock-iter-to-active-connections.patch` | [#2594](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2594) | Startup iterator only adds active established client connections (two-pass listening-port exclusion) instead of every socket on the host. |
| `005-h2-genuine-traffic-guard.patch` | [#2734](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2734) | Only inject HPACK traceparent into genuine HTTP/2 streams, preventing corruption of protocols that merely resemble H2 framing. Functional hunks only; upstream integration-test scaffolding omitted. |

None of these are in an OBI release tag yet (latest is v0.10.0); all are on upstream `main`.

## Verification

- Full patch stack (001–005) applies cleanly onto a pristine `v0.10.0` clone, mirroring the Dockerfile flow.
- `docker build --target obi-builder -f ebpf/Dockerfile .` passes: patches apply, `/generate.sh` regenerates BPF objects (including the new fixup program — the patched Go code only compiles if its generated bindings exist), `make compile` produces `bin/obi`.

## Rollout notes

- The workaround uses `bpf_probe_write_user`, which logs a one-time kernel taint warning at program load.
- On affected kernels the agent logs `kernel misreports ioctl(FIONREAD) for sockets in a sockhash … enabling BPF compensation` followed by `FIONREAD compensation verified` — useful for confirming the fix in the field.