### PR TITLE
Disable context propagation when the FIONREAD compensation cannot load

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.1.32
+ENV COLLECTOR_VERSION=1.1.33
 ENV VECTOR_VERSION=0.47.0
 ENV OBI_VERSION=0.10.0
 ENV CLUSTER_AGENT_VERSION=1.6.1

--- a/ebpf/patches/obi/006-disable-propagation-without-fionread-compensation.patch
+++ b/ebpf/patches/obi/006-disable-propagation-without-fionread-compensation.patch
@@ -1,0 +1,107 @@
+diff --git a/pkg/internal/ebpf/tpinjector/tpinjector.go b/pkg/internal/ebpf/tpinjector/tpinjector.go
+index 2ac375f..68936c8 100644
+--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
++++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
+@@ -37,6 +37,7 @@ type Tracer struct {
+ 	fionreadOnce            sync.Once
+ 	fionreadBroken          bool
+ 	fionreadFixupEnabled    bool
++	propagationDisabled     bool
+ }
+ 
+ func New(cfg *obi.Config) *Tracer {
+@@ -53,6 +54,29 @@ func (p *Tracer) AllowPID(app.PID, uint32, *exec.FileInfo) {}
+ func (p *Tracer) BlockPID(app.PID, uint32) {}
+ 
+ func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
++	// On kernels that misreport FIONREAD for sockets in a sockhash (commit
++	// 929e30f93125), enrolling sockets without the compensation stalls and
++	// truncates transfers for readers that size reads via the ioctl (nginx,
++	// Java NIO, .NET). The compensation needs bpf_probe_write_user, which
++	// kernel lockdown (Ubuntu default under UEFI Secure Boot) rejects at load
++	// time. Trace context is expendable; traffic is not: when the fixup cannot
++	// load, do not enroll sockets at all instead of proceeding broken.
++	var fixupSpec *ebpf.CollectionSpec
++	if p.kernelBreaksFIONREAD() {
++		var err error
++		fixupSpec, err = loadableFIONREADFixup()
++		if err != nil {
++			p.propagationDisabled = true
++			p.log.Warn("kernel misreports FIONREAD for sockets in a sockhash and the BPF "+
++				"compensation cannot be loaded (kernel lockdown?); disabling context "+
++				"propagation so proxied transfers (nginx, Java, .NET) are not stalled "+
++				"or truncated; set context_propagation: disabled "+
++				"(OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) to silence this warning",
++				"error", err)
++			return nil, nil
++		}
++	}
++
+ 	spec, err := LoadBpf()
+ 	if err != nil {
+ 		return nil, err
+@@ -81,23 +105,13 @@ func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
+ 		})
+ 	}
+ 
+-	// kernel lockdown rejects bpf_probe_write_user at load time
+-	if p.kernelBreaksFIONREAD() {
+-		fixupSpec, err := loadableFIONREADFixup()
+-		if err != nil {
+-			p.log.Error("kernel misreports FIONREAD for sockets in a sockhash and the BPF "+
+-				"compensation cannot be loaded (kernel lockdown?); applications sizing reads "+
+-				"via FIONREAD (nginx, Java, .NET) may stall or truncate transfers; "+
+-				"set context_propagation: disabled (OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) "+
+-				"to avoid impact", "error", err)
+-		} else {
+-			bundles = append(bundles, &ebpfcommon.SpecBundle{
+-				Spec:      fixupSpec,
+-				Objects:   &p.bpfFionreadFixupObjects,
+-				Constants: map[string]any{"g_bpf_debug": p.cfg.EBPF.BpfDebug},
+-			})
+-			p.fionreadFixupEnabled = true
+-		}
++	if fixupSpec != nil {
++		bundles = append(bundles, &ebpfcommon.SpecBundle{
++			Spec:      fixupSpec,
++			Objects:   &p.bpfFionreadFixupObjects,
++			Constants: map[string]any{"g_bpf_debug": p.cfg.EBPF.BpfDebug},
++		})
++		p.fionreadFixupEnabled = true
+ 	}
+ 
+ 	return bundles, nil
+@@ -174,6 +188,10 @@ func (p *Tracer) SocketFilters() []*ebpf.Program {
+ }
+ 
+ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
++	if p.propagationDisabled {
++		return nil
++	}
++
+ 	return []ebpfcommon.SockMsg{
+ 		{
+ 			Program:  p.bpfObjects.ObiPacketExtender,
+@@ -184,6 +202,10 @@ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
+ }
+ 
+ func (p *Tracer) SockOps() []ebpfcommon.SockOps {
++	if p.propagationDisabled {
++		return nil
++	}
++
+ 	return []ebpfcommon.SockOps{
+ 		{
+ 			Program:  p.bpfObjects.ObiSockmapTracker,
+@@ -197,6 +219,11 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
+ 		return p.iters
+ 	}
+ 
++	if p.propagationDisabled {
++		p.iters = []*ebpfcommon.Iter{}
++		return p.iters
++	}
++
+ 	major, minor := ebpfcommon.KernelVersion()
+ 
+ 	if major < 6 || (major == 6 && minor < 4) {


### PR DESCRIPTION
## Problem

#141's FIONREAD workaround (`003-fionread-sockhash-workaround.patch`) rewrites the ioctl result with `bpf_probe_write_user`. Kernel lockdown rejects that helper at BPF load time, and Ubuntu enables `lockdown=integrity` automatically whenever the host boots with UEFI Secure Boot — so this is a mainstream configuration, not an edge case.

On such hosts the agent currently logs an ERROR ("compensation cannot be loaded") and then attaches sockops/sk_msg anyway. Every socket still gets enrolled in `sock_dir`, `ioctl(FIONREAD)` still reports 0, and large proxied responses stall and truncate exactly as before #141. The loud log turns out to be the only difference.

Reproduced on Ubuntu 26.04 / kernel 7.0.0-22-generic / nginx 1.28.3 (`proxy_pass` over loopback, 175 KB body, image 1.1.32):

| lockdown | result |
|---|---|
| `none` | 20/20 transfers complete — compensation loads, `FIONREAD compensation verified` |
| `integrity` | 10/10 truncated at 3.9–24 KB, stall until `proxy_read_timeout`, nginx logs `upstream timed out (110)` |

`echo integrity > /sys/kernel/security/lockdown` plus an agent restart is a faithful single-boot repro of a Secure Boot host.

## Why not the alternatives

- The real kernel fix (torvalds/linux `04af4efde58a`, mainline since mid-July) hasn't reached Ubuntu resolute: nothing in the changelog through 7.0.0-29.
- Attaching a no-op SK_SKB verdict so the kernel takes the verdict-present receive path (upstream draft open-telemetry/opentelemetry-ebpf-instrumentation#2975) truncates large transfers on exactly the affected kernels, per upstream's own VM matrix run.
- There is no lockdown-compatible way to rewrite an ioctl result from BPF.

Which leaves: don't enroll sockets we can't keep healthy.

## Fix

`006-disable-propagation-without-fionread-compensation.patch` hoists the fixup load-check to the top of `LoadSpecs()`. On a misreporting kernel where the fixup can't load, the tracer marks itself disabled: it loads no specs and returns nothing from `SockMsgs()`, `SockOps()` and `Iters()`, so no socket ever enters `sock_dir` and the kernel's receive path stays untouched. Logged at Warn with the reason, matching the existing lockdown fallback in `tracer_linux.go`.

Cost: no trace-context propagation on locked-down hosts with affected kernels. Span capture is unaffected — only header/TCP-option injection goes away. Once Ubuntu ships the kernel fix, the runtime probe stops detecting the misreport and propagation comes back on its own.

The post-attach "compensation is ineffective" verification path is left as-is: it has no known trigger, and by the time it runs sockops is already attached — tearing that down cleanly is a bigger change than the case warrants.

## Verification

- Patch stack 001–006 applies cleanly onto a pristine `v0.10.0` clone, mirroring the Dockerfile flow.
- `docker build --target obi-builder -f ebpf/Dockerfile .` passes: patches apply, bindings regenerate, `make compile` produces `bin/obi`.
- Once CI publishes the `pr-` image I'll run it on the repro host both ways and post results here: lockdown `integrity` → transfers complete, Warn line present, no "Attaching sock ops"; lockdown `none` → unchanged, `FIONREAD compensation verified`.
