### PR TITLE
Rename better-stack-ebpf container to better-stack-collector-host

### DIFF
--- a/.github/workflows/docker-compose-match.yml
+++ b/.github/workflows/docker-compose-match.yml
@@ -30,14 +30,14 @@ jobs:
         fi
         echo "✓ Diff is exactly 3 lines as expected"
 
-    - name: check ebpf section matches between docker-compose.yml and swarm/docker-compose.swarm-ebpf.yml
+    - name: check collector-host section matches between docker-compose.yml and swarm/docker-compose.swarm-ebpf.yml
       run: |
-        # Extract ebpf service from docker-compose.yml, excluding build: and depends_on: sections
+        # Extract collector-host service from docker-compose.yml, excluding build: and depends_on: sections
         # These sections are not applicable in the swarm ebpf file
         # Also exclude INSTALLED_AS= line as it's intentionally different (docker vs swarm)
         awk '
           BEGIN { in_ebpf = 0; skip_block = 0; block_indent = 0 }
-          /^  ebpf:$/ { in_ebpf = 1; next }
+          /^  collector-host:$/ { in_ebpf = 1; next }
           in_ebpf == 1 {
             # Skip build: and depends_on: blocks (4 spaces = service property level)
             if (/^    build:/ || /^    depends_on:/) {
@@ -64,28 +64,28 @@ jobs:
           }
         ' docker-compose.yml > /tmp/ebpf-main.yml
 
-        # Extract ebpf service from swarm file (skip header comments and services: line)
+        # Extract collector-host service from swarm file (skip header comments and services: line)
         # Also exclude INSTALLED_AS= line as it's intentionally different (docker vs swarm)
         awk '
           BEGIN { in_ebpf = 0 }
-          /^  ebpf:$/ { in_ebpf = 1; next }
+          /^  collector-host:$/ { in_ebpf = 1; next }
           /INSTALLED_AS=/ { next }
           in_ebpf == 1 { print }
         ' swarm/docker-compose.swarm-ebpf.yml > /tmp/ebpf-swarm.yml
 
         # Compare the extracted sections
-        echo "=== docker-compose.yml ebpf section (excluding build/depends_on) ==="
+        echo "=== docker-compose.yml collector-host section (excluding build/depends_on) ==="
         cat /tmp/ebpf-main.yml
         echo ""
-        echo "=== swarm/docker-compose.swarm-ebpf.yml ebpf section ==="
+        echo "=== swarm/docker-compose.swarm-ebpf.yml collector-host section ==="
         cat /tmp/ebpf-swarm.yml
         echo ""
 
         if ! diff -q /tmp/ebpf-main.yml /tmp/ebpf-swarm.yml > /dev/null; then
-          echo "ERROR: ebpf sections do not match!"
+          echo "ERROR: collector-host sections do not match!"
           echo ""
           echo "=== Differences ==="
           diff /tmp/ebpf-main.yml /tmp/ebpf-swarm.yml || true
           exit 1
         fi
-        echo "✓ ebpf sections match between docker-compose.yml and swarm/docker-compose.swarm-ebpf.yml"
+        echo "✓ collector-host sections match between docker-compose.yml and swarm/docker-compose.swarm-ebpf.yml"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ On container start:
 
 ### Container Naming Conventions
 
-- **Docker Compose** (install.sh): containers named `better-stack-collector` and `better-stack-ebpf` (hyphens)
+- **Docker Compose** (install.sh): containers named `better-stack-collector` and `better-stack-collector-host` (hyphens); older names `better-stack-ebpf` and `better-stack-beyla` are removed on upgrade
 - **Docker Swarm** (deploy-to-swarm.sh): service appears as `better-stack_collector` (underscore, from stack name `better-stack` + service `collector`)
 
 Both install.sh and deploy-to-swarm.sh check for the other's naming convention to prevent double-installation.

--- a/deploy-to-swarm.sh
+++ b/deploy-to-swarm.sh
@@ -424,19 +424,21 @@ deploy_ebpf_to_node() {
         export HOSTNAME=\$(hostname)
         export ENABLE_DOCKERPROBE="$enable_dockerprobe"
 
-        # Stop old better-stack-beyla service if it exists (for upgrades from older versions)
-        echo "Stopping old better-stack-beyla service if present..."
+        # Stop old project names if present (for upgrades from older versions:
+        # the agent was previously deployed as better-stack-ebpf, and before that better-stack-beyla)
+        echo "Stopping old better-stack-ebpf/better-stack-beyla services if present..."
+        \$COMPOSE_CMD -p better-stack-ebpf down 2>/dev/null || true
         \$COMPOSE_CMD -p better-stack-beyla down 2>/dev/null || true
 
         # Pull and start eBPF agent
         echo "Pulling eBPF image..."
-        \$COMPOSE_CMD -f docker-compose.yml -p better-stack-ebpf pull
+        \$COMPOSE_CMD -f docker-compose.yml -p better-stack-collector-host pull
 
         echo "Starting eBPF agent..."
-        \$COMPOSE_CMD -f docker-compose.yml -p better-stack-ebpf up -d
+        \$COMPOSE_CMD -f docker-compose.yml -p better-stack-collector-host up -d
 
         echo "Checking eBPF agent status..."
-        docker ps --filter "name=better-stack-ebpf" --format "table {{.Names}}\t{{.Status}}"
+        docker ps --filter "name=better-stack-collector-host" --format "table {{.Names}}\t{{.Status}}"
 EOF
     then
         print_green "✓ eBPF agent installed on $node"
@@ -457,16 +459,20 @@ uninstall_ebpf_from_node() {
 
         echo "Stopping and removing eBPF agent container..."
 
-        # Try docker-compose first (handle both old and new project names)
+        # Try docker-compose first (handle current and old project names)
         if docker compose version &> /dev/null; then
+            docker compose -p better-stack-collector-host down 2>/dev/null || true
             docker compose -p better-stack-ebpf down 2>/dev/null || true
             docker compose -p better-stack-beyla down 2>/dev/null || true
         elif docker-compose version &> /dev/null; then
+            docker-compose -p better-stack-collector-host down 2>/dev/null || true
             docker-compose -p better-stack-ebpf down 2>/dev/null || true
             docker-compose -p better-stack-beyla down 2>/dev/null || true
         fi
 
-        # Also try direct container removal as fallback (handle both old and new names)
+        # Also try direct container removal as fallback (handle current and old names)
+        docker stop better-stack-collector-host 2>/dev/null || true
+        docker rm better-stack-collector-host 2>/dev/null || true
         docker stop better-stack-ebpf 2>/dev/null || true
         docker rm better-stack-ebpf 2>/dev/null || true
         docker stop better-stack-beyla 2>/dev/null || true

--- a/development.md
+++ b/development.md
@@ -19,7 +19,7 @@ docker compose up
 Tail collector logs:
 
 - Collector container: `docker exec -it better-stack-collector bash -c "tail -f /var/log/supervisor/*"`
-- eBPF container: `docker logs -f better-stack-ebpf`
+- Host agent container: `docker logs -f better-stack-collector-host`
 
 ## Development troubleshooting
 

--- a/docker-compose.seccomp.yml
+++ b/docker-compose.seccomp.yml
@@ -34,12 +34,12 @@ services:
       - /:/host:ro
       - /var/lib/better-stack:/var/lib/better-stack
 
-  ebpf:
+  collector-host:
     build:
       context: .
       dockerfile: ebpf/Dockerfile
     image: ghcr.io/betterstackhq/collector-ebpf:latest
-    container_name: better-stack-ebpf
+    container_name: better-stack-collector-host
     restart: always
     init: true
     stop_signal: SIGTERM

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,12 @@ services:
       - /:/host:ro
       - /var/lib/better-stack:/var/lib/better-stack
 
-  ebpf:
+  collector-host:
     build:
       context: .
       dockerfile: ebpf/Dockerfile
     image: ghcr.io/betterstackhq/collector-ebpf:latest
-    container_name: better-stack-ebpf
+    container_name: better-stack-collector-host
     restart: always
     init: true
     stop_signal: SIGTERM

--- a/install.sh
+++ b/install.sh
@@ -290,7 +290,10 @@ if [ "$COMPOSE_CMD" = "docker-compose" ]; then
     $COMPOSE_CMD -p better-stack-collector stop -t 90 || true
 fi
 
-# Stop old better-stack-beyla container if it exists (for upgrades from older versions)
+# Stop old container names if they exist (for upgrades from older versions:
+# the privileged sidecar was previously named better-stack-ebpf, and before that better-stack-beyla)
+docker stop better-stack-ebpf 2>/dev/null || true
+docker rm better-stack-ebpf 2>/dev/null || true
 docker stop better-stack-beyla 2>/dev/null || true
 docker rm better-stack-beyla 2>/dev/null || true
 

--- a/swarm/docker-compose.swarm-ebpf.yml
+++ b/swarm/docker-compose.swarm-ebpf.yml
@@ -1,5 +1,5 @@
 # eBPF container for Docker Swarm nodes
-# Deploy with: docker compose -f docker-compose.swarm-ebpf.yml -p better-stack-ebpf up -d
+# Deploy with: docker compose -f docker-compose.swarm-ebpf.yml -p better-stack-collector-host up -d
 #
 # This runs outside of Docker Swarm as a regular docker-compose service because eBPF agent requires:
 # - network_mode: host (for eBPF network tracing)
@@ -9,9 +9,9 @@
 # These options are not supported in Docker Swarm services.
 
 services:
-  ebpf:
+  collector-host:
     image: ghcr.io/betterstackhq/collector-ebpf:latest
-    container_name: better-stack-ebpf
+    container_name: better-stack-collector-host
     restart: always
     init: true
     stop_signal: SIGTERM

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -20,9 +20,9 @@ fi
 # Fallback for docker-compose v1 or when compose is not available
 echo "Docker Compose v2 not found, using direct Docker commands..."
 
-# Stop and remove containers (eBPF agent first since it depends on collector)
-# Handle both old (better-stack-beyla) and new (better-stack-ebpf) container names
-for container in better-stack-ebpf better-stack-beyla better-stack-collector; do
+# Stop and remove containers (host agent first since it depends on collector)
+# Handle current (better-stack-collector-host) and old (better-stack-ebpf, better-stack-beyla) container names
+for container in better-stack-collector-host better-stack-ebpf better-stack-beyla better-stack-collector; do
     if docker ps -a --format "{{.Names}}" | grep -q "^${container}$"; then
         echo "Stopping container: $container"
         docker stop "$container" 2>/dev/null || true


### PR DESCRIPTION
The privileged sidecar has outgrown its name: besides the eBPF agents it now ships node_exporter, database exporters, and dockerprobe, so a container named `better-stack-ebpf` confuses anyone who has disabled all eBPF components and still sees it running.

- Compose service `ebpf` is now `collector-host`; the container is `better-stack-collector-host` (Compose and Swarm).
- Fresh installs use the new name. Upgrades via `install.sh` / `deploy-to-swarm.sh` stop and remove the old `better-stack-ebpf` / `better-stack-beyla` containers and compose projects first, extending the approach from the previous beyla rename.
- `uninstall.sh` removes current and old names.
- Image names (`ghcr.io/betterstackhq/collector-ebpf`), Dockerfiles, and on-disk paths (`/var/lib/better-stack/ebpf`) are unchanged.

Verified: `docker compose config` on all three compose files, `bash -n` on the shell scripts, and the compose-match CI check replicated locally with the updated service key.