### PR TITLE
Fix compose-mode detection tripping on better-stack-collector-host

### DIFF
--- a/deploy-to-swarm.sh
+++ b/deploy-to-swarm.sh
@@ -509,7 +509,9 @@ if [[ "$ACTION" == "install" || "$ACTION" == "force_upgrade" ]]; then
     COMPOSE_NODES=""
     for NODE in $NODES; do
         node_target=$(get_node_target "$NODE")
-        COMPOSE_CONTAINER=$(${SSH_CMD} "$node_target" "docker ps --filter 'name=better-stack-collector' --format '{{.Names}}'" </dev/null 2>/dev/null || true)
+        # Match the container name exactly: the docker ps name filter is a substring match,
+        # and swarm nodes run the better-stack-collector-host container which would trip it.
+        COMPOSE_CONTAINER=$(${SSH_CMD} "$node_target" "docker ps --format '{{.Names}}' | grep -x better-stack-collector" </dev/null 2>/dev/null || true)
         if [[ -n "$COMPOSE_CONTAINER" ]]; then
             COMPOSE_NODES="${COMPOSE_NODES:+$COMPOSE_NODES, }$NODE"
         fi


### PR DESCRIPTION
Since the container rename, `deploy-to-swarm.sh` upgrades abort on every node with:

```
Error: Better Stack collector is already installed via docker-compose on: <node>
```

The compose-mode guard uses `docker ps --filter 'name=better-stack-collector'`, and Docker's `name` filter is a substring match, so the swarm node's own standalone `better-stack-collector-host` agent trips it. Before the rename the sidecar was `better-stack-ebpf`, which never collided.

Fix: list names and match `better-stack-collector` exactly (`grep -x`). Compose-mode installs are still detected via their main container; swarm redeploys and upgrades pass again.

Verified: `bash -n`, plus the pipeline against both name sets (sidecar-only node -> no match; compose node -> match). Reproduced by the swarm upgrade E2E, which re-runs the deploy script against an already-deployed node.