### PR TITLE
Add mysqld_exporter binary

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /versions/0-default \
 # Set environment variables
 ENV BASE_URL=https://telemetry.betterstack.com
 ENV CLUSTER_COLLECTOR=false
-ENV COLLECTOR_VERSION=1.1.36
+ENV COLLECTOR_VERSION=1.1.37
 ENV VECTOR_VERSION=0.47.0
 ENV OBI_VERSION=0.12.2
 ENV CLUSTER_AGENT_VERSION=1.6.1

--- a/ebpf/Dockerfile
+++ b/ebpf/Dockerfile
@@ -51,6 +51,9 @@ FROM quay.io/prometheuscommunity/elasticsearch-exporter:v1.11.0 AS elasticsearch
 # Add pgbouncer exporter to the image
 FROM prometheuscommunity/pgbouncer-exporter:v0.12.0 AS pgbouncer-exporter
 
+# Add mysqld exporter to the image
+FROM prom/mysqld-exporter:v0.20.0 AS mysqld-exporter
+
 # Build OBI from source with patches
 FROM ghcr.io/open-telemetry/obi-generator:0.2.15@sha256:9cbb1b567377d5779b04e6bcdb87431c77a19e797b4630eba30f5417de96ea33 AS obi-builder
 RUN apk add --no-cache bash git make
@@ -122,6 +125,9 @@ COPY --from=elasticsearch-exporter --chmod=755 /bin/elasticsearch_exporter /usr/
 
 # Copy PgBouncer exporter
 COPY --from=pgbouncer-exporter --chmod=755 /bin/pgbouncer_exporter /usr/local/bin/pgbouncer_exporter
+
+# Copy MySQL exporter
+COPY --from=mysqld-exporter --chmod=755 /bin/mysqld_exporter /usr/local/bin/mysqld_exporter
 
 COPY ebpf/bootstrap_supervisord.conf /bootstrap/supervisord.conf
 COPY --chmod=755 ebpf/run_supervisord.sh /run_supervisord.sh


### PR DESCRIPTION
Adds the Prometheus mysqld_exporter to the eBPF image, following the same pattern as the other exporters: an upstream image stage plus a binary copy into /usr/local/bin.

- Pinned to prom/mysqld-exporter:v0.20.0; the upstream manifest covers both linux/amd64 and linux/arm64, and the binary runs and reports 0.20.0.
- Bumps COLLECTOR_VERSION to 1.1.37.