### PR TITLE
eBPF: never inject on a stale tpinjector scratch buffer

### DIFF
--- a/ebpf/patches/obi/009-never-inject-on-stale-msg-buffer.patch
+++ b/ebpf/patches/obi/009-never-inject-on-stale-msg-buffer.patch
@@ -1,0 +1,45 @@
+diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
+index 90323d28..a5febb70 100644
+--- a/bpf/tpinjector/tpinjector.c
++++ b/bpf/tpinjector/tpinjector.c
+@@ -1115,7 +1115,18 @@ static __always_inline bool handle_existing_tp_pid(struct sk_msg_md *msg,
+     }
+ 
+     bpf_msg_pull_data(msg, 0, msg->size, 0);
+-    fill_msg_buffers(msg, p_conn, e_key);
++
++    // If the scratch buffer wasn't refreshed from *this* message (SSL
++    // payload, empty message, or allocation failure), protocol_detector
++    // would judge stale bytes left by a previous message on this CPU. A
++    // stale plaintext HTTP request start would make it approve injecting
++    // into what is actually opaque data (e.g. TLS ciphertext, which the
++    // splice would corrupt into a peer-side bad_record_mac). Never detect
++    // or inject on a stale buffer.
++    if (!fill_msg_buffers(msg, p_conn, e_key)) {
++        clear_tp_info_pid(e_key);
++        return true;
++    }
+ 
+     const bool is_http = protocol_detector(msg, id, &p_conn->conn);
+     if (is_http) {
+@@ -1201,7 +1212,10 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+     }
+ 
+     bpf_msg_pull_data(msg, 0, msg->size, 0);
+-    fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
++    // See handle_existing_tp_pid: a stale scratch buffer must never reach
++    // protocol_detector. H2 handling below is unaffected, it reads the
++    // message directly and has its own SSL guards.
++    const bool fresh_buffers = fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
+ 
+     if (is_h2_socket(msg)) {
+         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
+@@ -1216,7 +1230,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+     bpf_dbg_printk("MSG TO=%llx:%d", conn.d_ip[3], conn.d_port);
+     bpf_dbg_printk("MSG SIZE=%u", msg->size);
+ 
+-    const bool is_http = protocol_detector(msg, id, &conn);
++    const bool is_http = fresh_buffers && protocol_detector(msg, id, &conn);
+     if (is_http) {
+         bpf_dbg_printk("len=%d, s_port=%d", msg->size, msg->local_port);
+         init_tp_ctx_parent_tp(t_ctx);

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -9,3 +9,9 @@ Currently contains patches:
 * 008-never-inject-after-http-upgrade.patch
   Prevent OBI from injecting after HTTP upgrade (e.g. WebSocket) requests, which
   would break the connection.
+* 009-never-inject-on-stale-msg-buffer.patch
+  Only run tpinjector's HTTP request detection when fill_msg_buffers actually
+  refreshed the per-CPU scratch buffer from the current message. On SSL
+  connections the fill deliberately bails, so the detector would otherwise judge
+  stale bytes from a previous message and could splice a Traceparent header into
+  TLS ciphertext, corrupting the stream (peer-side bad_record_mac).


### PR DESCRIPTION
## Problem

OBI's `tpinjector` sk_msg program can splice a 70-byte `Traceparent:` header into outbound **TLS ciphertext**, corrupting the record so the remote peer fails its MAC check and aborts with a `bad_record_mac` TLS alert (alert 20). Observed as a sustained, low-rate, probabilistic failure of outbound HTTPS from an nginx forward proxy on an instrumented host; retries of the identical request succeed.

Root cause in OBI v0.12.2 (`bpf/tpinjector/tpinjector.c`):

1. `fill_msg_buffers()` is supposed to copy the outgoing bytes into the per-CPU scratch map `msg_buffer_mem`, but for known-SSL connections it early-returns **without touching the buffer** (`:711-713`).
2. Both call sites ignore the return value (`:1118`, `:1204`).
3. `protocol_detector()` never reads the actual message; it reads only the per-CPU scratch (`:767-777`). A stale plaintext `POST /... HTTP/1.1` left by a previous message on the same CPU makes it classify a TLS message as an HTTP request.
4. The HTTP/1 inject chain then `bpf_msg_push_data`s the traceparent after the first `0x0A` byte found in the ciphertext.

The `valid=0` shield entry written by the SSL uretprobe protects most sends, but is lost on a connection's first write (SSL binding happens after sk_msg), on `SSL_write` retries, on LRU eviction of the host-wide 10k-entry map, and on egress-key collisions (the key is ports-only). Whenever a shield gap coincides with a poisoned CPU buffer, the splice fires. The H2 path already guards exactly this false-positive class (`:1075-1078`); the HTTP/1 path never did.

## Fix

Patch `009-never-inject-on-stale-msg-buffer.patch`: honor `fill_msg_buffers()`' return at both call sites. No fresh buffer, no detection, no injection. In `handle_existing_tp_pid` a failed fill now clears the map entry and terminates handling for the message, mirroring the existing detector-failure path. H2 handling is untouched.

## Verification

- `git apply --check` clean on v0.12.2 + patch 008.
- Full `generate.sh` + `make compile` of the patched tree in `obi-generator:0.2.15` passes (exit 0).

Will also be proposed upstream separately.
