### PR TITLE
eBPF: default-deny tpinjector injection gate + egress-integrity CI

### DIFF
--- a/.github/workflows/obi-patch-ci.yml
+++ b/.github/workflows/obi-patch-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "ebpf/patches/obi/**"
+      - "ebpf/tests/egress-integrity/**"
       - "ebpf/Dockerfile"
       - ".github/workflows/obi-patch-ci.yml"
   push:
@@ -11,6 +12,7 @@ on:
       - main
     paths:
       - "ebpf/patches/obi/**"
+      - "ebpf/tests/egress-integrity/**"
       - "ebpf/Dockerfile"
       - ".github/workflows/obi-patch-ci.yml"
 
@@ -72,3 +74,110 @@ jobs:
 
       - name: Build production OBI stage
         run: docker build --target obi-builder --file ebpf/Dockerfile .
+
+  egress-integrity:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read OBI build pins
+        run: |
+          {
+            echo "OBI_VERSION=$(grep -oP '^ARG OBI_VERSION=\K.*' ebpf/Dockerfile | head -1 | tr -d '\"')"
+            echo "OBI_REVISION=$(grep -oP '^ARG OBI_REVISION=\K.*' ebpf/Dockerfile | head -1 | tr -d '\"')"
+          } >> "$GITHUB_ENV"
+
+      - name: Clone OBI and apply patches
+        run: |
+          git clone --depth 1 --branch "$OBI_VERSION" \
+            https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation.git "$RUNNER_TEMP/obi"
+          test "$(git -C "$RUNNER_TEMP/obi" rev-parse HEAD)" = "$OBI_REVISION"
+          for p in "$GITHUB_WORKSPACE"/ebpf/patches/obi/*.patch; do
+            [ -e "$p" ] || break
+            git -C "$RUNNER_TEMP/obi" apply "$p"
+          done
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: ebpf/tests/egress-integrity/go.mod
+          cache: false
+
+      - name: Build egress-integrity payload
+        working-directory: ebpf/tests/egress-integrity
+        run: go build -o "$RUNNER_TEMP/egress-integrity" .
+
+      - name: Build and extract patched OBI
+        run: |
+          docker build --platform linux/amd64 --target obi-builder \
+            --tag obi-egress-builder --file ebpf/Dockerfile .
+          container="$(docker create obi-egress-builder)"
+          trap 'docker rm -f "$container"' EXIT
+          docker cp "$container:/tmp/obi/bin/obi" "$RUNNER_TEMP/ebpf-instrument"
+          chmod +x "$RUNNER_TEMP/ebpf-instrument"
+          test -x "$RUNNER_TEMP/ebpf-instrument"
+
+      - name: Self-check payload
+        run: $RUNNER_TEMP/egress-integrity -selfcheck
+
+      - name: Verify egress integrity under OBI
+        run: |
+          cat >"$RUNNER_TEMP/obi-test.yml" <<'YAML'
+          log_level: debug
+          trace_printer: text
+          discovery:
+            instrument:
+              - exe_path: "*egress-integrity*"
+          ebpf:
+            context_propagation: headers,tcp
+          YAML
+
+          obi_log="$RUNNER_TEMP/obi.log"
+          payload_log="$RUNNER_TEMP/egress-integrity.log"
+          start_file="$RUNNER_TEMP/egress-integrity.start"
+          obi_pid=
+          payload_pid=
+          cleanup() {
+            status=$?
+            set +e
+            [ -n "$payload_pid" ] && kill "$payload_pid" 2>/dev/null
+            [ -n "$obi_pid" ] && sudo kill "$obi_pid" 2>/dev/null
+            [ -n "$payload_pid" ] && wait "$payload_pid" 2>/dev/null
+            [ -n "$obi_pid" ] && wait "$obi_pid" 2>/dev/null
+            if [ "$status" -ne 0 ]; then
+              echo "::group::OBI log"
+              cat "$obi_log"
+              echo "::endgroup::"
+              echo "::group::egress-integrity log"
+              cat "$payload_log"
+              echo "::endgroup::"
+            fi
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          sudo "$RUNNER_TEMP/ebpf-instrument" -config "$RUNNER_TEMP/obi-test.yml" >"$obi_log" 2>&1 &
+          obi_pid=$!
+          "$RUNNER_TEMP/egress-integrity" -start-file "$start_file" >"$payload_log" 2>&1 &
+          payload_pid=$!
+
+          ready=
+          for _ in {1..60}; do
+            if grep -q "tpinjector started" "$obi_log"; then
+              ready=1
+              break
+            fi
+            if ! sudo kill -0 "$obi_pid" 2>/dev/null; then
+              echo "OBI exited before tpinjector readiness"
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ -z "$ready" ]; then
+            echo "timed out waiting for tpinjector readiness"
+            exit 1
+          fi
+
+          touch "$start_file"
+          wait "$payload_pid"
+          cat "$payload_log"

--- a/.github/workflows/obi-patch-ci.yml
+++ b/.github/workflows/obi-patch-ci.yml
@@ -158,7 +158,8 @@ jobs:
 
           sudo "$RUNNER_TEMP/ebpf-instrument" -config "$RUNNER_TEMP/obi-test.yml" >"$obi_log" 2>&1 &
           obi_pid=$!
-          "$RUNNER_TEMP/egress-integrity" -start-file "$start_file" >"$payload_log" 2>&1 &
+          timeout --signal=TERM --kill-after=10s 150s \
+            "$RUNNER_TEMP/egress-integrity" -start-file "$start_file" >"$payload_log" 2>&1 &
           payload_pid=$!
 
           ready=

--- a/.github/workflows/obi-patch-ci.yml
+++ b/.github/workflows/obi-patch-ci.yml
@@ -132,53 +132,27 @@ jobs:
             context_propagation: headers,tcp
           YAML
 
-          obi_log="$RUNNER_TEMP/obi.log"
-          payload_log="$RUNNER_TEMP/egress-integrity.log"
-          start_file="$RUNNER_TEMP/egress-integrity.start"
-          obi_pid=
-          payload_pid=
+          container="obi-egress-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cleanup() {
             status=$?
             set +e
-            [ -n "$payload_pid" ] && kill "$payload_pid" 2>/dev/null
-            [ -n "$obi_pid" ] && sudo kill "$obi_pid" 2>/dev/null
-            [ -n "$payload_pid" ] && wait "$payload_pid" 2>/dev/null
-            [ -n "$obi_pid" ] && wait "$obi_pid" 2>/dev/null
-            if [ "$status" -ne 0 ]; then
-              echo "::group::OBI log"
-              cat "$obi_log"
-              echo "::endgroup::"
-              echo "::group::egress-integrity log"
-              cat "$payload_log"
-              echo "::endgroup::"
-            fi
+            docker rm -f "$container" >/dev/null 2>&1
             exit "$status"
           }
           trap cleanup EXIT
 
-          sudo "$RUNNER_TEMP/ebpf-instrument" -config "$RUNNER_TEMP/obi-test.yml" >"$obi_log" 2>&1 &
-          obi_pid=$!
-          timeout --signal=TERM --kill-after=10s 150s \
-            "$RUNNER_TEMP/egress-integrity" -start-file "$start_file" >"$payload_log" 2>&1 &
-          payload_pid=$!
-
-          ready=
-          for _ in {1..60}; do
-            if grep -q "tpinjector started" "$obi_log"; then
-              ready=1
-              break
-            fi
-            if ! sudo kill -0 "$obi_pid" 2>/dev/null; then
-              echo "OBI exited before tpinjector readiness"
-              exit 1
-            fi
-            sleep 1
-          done
-          if [ -z "$ready" ]; then
-            echo "timed out waiting for tpinjector readiness"
-            exit 1
-          fi
-
-          touch "$start_file"
-          wait "$payload_pid"
-          cat "$payload_log"
+          timeout --signal=TERM --kill-after=10s 240s \
+            docker run --name "$container" --rm \
+              --platform linux/amd64 \
+              --privileged \
+              --cgroupns=private \
+              --network=none \
+              --mount "type=bind,source=$RUNNER_TEMP/ebpf-instrument,target=/opt/ebpf-instrument,readonly" \
+              --mount "type=bind,source=$RUNNER_TEMP/egress-integrity,target=/opt/egress-integrity,readonly" \
+              --mount "type=bind,source=$RUNNER_TEMP/obi-test.yml,target=/opt/obi-test.yml,readonly" \
+              --mount "type=bind,source=$GITHUB_WORKSPACE/ebpf/tests/egress-integrity/run-under-obi.sh,target=/opt/run-under-obi.sh,readonly" \
+              ubuntu:22.04 \
+              /opt/run-under-obi.sh \
+                /opt/ebpf-instrument \
+                /opt/egress-integrity \
+                /opt/obi-test.yml

--- a/ebpf/patches/obi/010-default-deny-injection-gate.patch
+++ b/ebpf/patches/obi/010-default-deny-injection-gate.patch
@@ -26,7 +26,7 @@ index 00000000..da2ac5fd
 +    __type(value, u8);
 +} sk_inject_gate SEC(".maps");
 diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
-index a5febb70..a8f24a14 100644
+index a5febb70..c6dcdbbc 100644
 --- a/bpf/tpinjector/tpinjector.c
 +++ b/bpf/tpinjector/tpinjector.c
 @@ -45,6 +45,7 @@
@@ -37,7 +37,107 @@ index a5febb70..a8f24a14 100644
  #include <tpinjector/maps/sk_tp_info_pid_map.h>
  
  char __license[] SEC("license") = "Dual MIT/GPL";
-@@ -343,6 +344,227 @@ static __always_inline bool http1_upgrade_completed(struct sk_msg_md *msg) {
+@@ -55,24 +56,45 @@ char __license[] SEC("license") = "Dual MIT/GPL";
+ //
+ //   obi_packet_extender (sk_msg entry)
+ //   │
++//   ├── socket parked → SK_PASS        │  Default-deny: this stream left
++//   │                                  │  HTTP/1, never touch it again
++//   ├── pull_data + fill_msg_buffers   │  Committed to processing
++//   │                                  │
++//   └── H2 socket / stale buffer?      │  Gate cannot judge those bytes
++//         ├── yes → http1_dispatch     │
++//         └── no  → http1_request_line │
++//
++//   obi_packet_extender_http1_request_line
++//   │                                     Strict method SP target SP
++//   ├── fail → http1_dispatch             "HTTP/1." DIGIT CRLF at offset 0
++//   └── pass → http1_upgrade
++//
++//   obi_packet_extender_http1_upgrade
++//   │                                     Bounded case-insensitive search
++//   ├── "\r\nupgrade:" → park, SK_PASS    for a request Upgrade field
++//   └── else → http1_dispatch
++//
++//   Each scan gets its own program: a tail call ends the program, so the
++//   precise loop offsets the verifier tracks fan out into a handful of
++//   instructions instead of the whole dispatch below.
++//
++//   obi_packet_extender_http1_dispatch
++//   │
+ //   ├── tp_pid && !is_h2_socket?      ─┐  Central dispatch: Go net/http,
+-//   │     └── handle_existing_tp_pid   │  SSL. Pulls+fills internally after
+-//   │                                  │  passing valid check, then injects.
++//   │     └── handle_existing_tp_pid   │  injects only when the gate passed
+ //   │                                  │  H2 sockets skip this — they carry
+ //   │                                  │  per-stream traceparents in HPACK
+ //   │                                  │
+-//   ├── is_go_grpc_client_conn?        │  Go gRPC: pull+fill, then detect_h2
+-//   │     └── pull+fill, detect_h2     │  injects only streams whose stored
+-//   │                                  │  tp has written=0 (uprobe miss)
++//   ├── is_go_grpc_client_conn?        │  Go gRPC: detect_h2 injects only
++//   │     └── detect_h2                │  streams whose stored tp has
++//   │                                  │  written=0 (uprobe miss)
+ //   │                                  │
+-//   ├── !valid_pid → SK_PASS           │  Unmonitored process — no pull
+-//   │                                  │
+-//   ├── pull_data + fill_msg_buffers   │  Committed to processing
++//   ├── !valid_pid → SK_PASS           │  Unmonitored process
+ //   │                                  │
+ //   ├── is_h2_socket?                  │  Preface seen / confirmed H2: skip
+ //   │     └─ tail-call detect_h2       │  preface check, drive the H2 chain
+ //   │                                 │
+-//   ├── HTTP/1 detected?              │  ── find_existing_tp ── create_tp ──
++//   ├── HTTP/1 gate passed?           │  ── find_existing_tp ── create_tp ──
+ //   │                                 │     write_msg_traceparent
+ //   │                                 │
+ //   └── fall through ─────────────────┴─▶ wrap_http2_traceparent
+@@ -134,6 +156,9 @@ enum {
+     k_tail_validate_h2_tp,
+     k_tail_detect_h2,
+     k_tail_sniff_h2,
++    k_tail_http1_request_line,
++    k_tail_http1_upgrade,
++    k_tail_http1_dispatch,
+ };
+ 
+ int obi_packet_extender_write_msg_tp(struct sk_msg_md *msg);
+@@ -145,10 +170,13 @@ int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg);
+ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg);
+ int obi_packet_extender_detect_h2(struct sk_msg_md *msg);
+ int obi_packet_extender_sniff_h2(struct sk_msg_md *msg);
++int obi_packet_extender_http1_request_line(struct sk_msg_md *msg);
++int obi_packet_extender_http1_upgrade(struct sk_msg_md *msg);
++int obi_packet_extender_http1_dispatch(struct sk_msg_md *msg);
+ 
+ struct {
+     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+-    __uint(max_entries, 9);
++    __uint(max_entries, 12);
+     __uint(key_size, sizeof(u32));
+     __array(values, int(void *));
+ } extender_jump_table SEC(".maps") = {
+@@ -163,6 +191,9 @@ struct {
+             [k_tail_validate_h2_tp] = (void *)&obi_packet_extender_validate_h2_tp,
+             [k_tail_detect_h2] = (void *)&obi_packet_extender_detect_h2,
+             [k_tail_sniff_h2] = (void *)&obi_packet_extender_sniff_h2,
++            [k_tail_http1_request_line] = (void *)&obi_packet_extender_http1_request_line,
++            [k_tail_http1_upgrade] = (void *)&obi_packet_extender_http1_upgrade,
++            [k_tail_http1_dispatch] = (void *)&obi_packet_extender_http1_dispatch,
+         },
+ };
+ 
+@@ -185,7 +216,9 @@ typedef struct tailcall_ctx {
+     bool go_grpc_conn;            // Go gRPC egress: use uprobe-stored tps, never create
+     bool tp_present;              // frame already carries a traceparent we cannot adopt
+     bool scan_exhausted;          // retry budget ran out before the block was walked
++    bool http1_req;               // gate verdict: this message is an injectable HTTP/1 request
+     u8 opener;                    // first HPACK field byte of the frame being considered
++    u8 _pad[7];                   // -Wpadded is an error here, keep the tail explicit
+ } tailcall_ctx;
+ 
+ SCRATCH_MEM(tailcall_ctx);
+@@ -343,6 +376,226 @@ static __always_inline bool http1_upgrade_completed(struct sk_msg_md *msg) {
      return is_http1_101_response(msg->data, msg->data_end);
  }
  
@@ -96,9 +196,9 @@ index a5febb70..a8f24a14 100644
 +    k_http1_gate_scan_mask = k_http1_gate_scan_max - 1,
 +    // "GET / HTTP/1.1\r\n" — the shortest request line that can exist.
 +    k_http1_min_request_line = 16,
-+    // What the SP after the request-target must be followed by:
-+    // "HTTP/1." DIGIT CR LF.
-+    k_http1_version_span = 10,
++    // SP "HTTP/1." DIGIT — the nine bytes that must sit immediately before the
++    // CRLF that ends a request line.
++    k_http1_version_tail = 9,
 +    // "\r\nupgrade:"
 +    k_http1_upgrade_span = 10,
 +};
@@ -132,67 +232,85 @@ index a5febb70..a8f24a14 100644
 +    return 0;
 +}
 +
-+// A complete RFC 9112 3.1 request line at offset 0:
++// True when offset 0 holds a complete RFC 9112 3.1 request line:
 +//
 +//     method SP request-target SP "HTTP/1." DIGIT CRLF
 +//
-+// Returns the offset just past the CRLF, 0 when the bytes are not a request
-+// line. is_http_request_buf accepts a method prefix plus one target byte and
-+// nothing else, so any framing whose payload happens to open "GET /" passes
-+// it — harmless for generictracer, which only classifies, fatal for the
-+// injector, which mutates whatever it approves. The version token is what
-+// binary payloads cannot fake by accident, so it is the part that matters.
-+// The loose check stays as it is in bpf/common/http_types.h on purpose:
-+// tightening it there would change the generic tracer's read-only view of
-+// unrelated traffic.
-+static __always_inline u32 http1_request_line_end(const unsigned char *buf, u32 len) {
++// is_http_request_buf accepts a method prefix plus one target byte and nothing
++// else, so any framing whose payload happens to open "GET /" passes it —
++// harmless for generictracer, which only classifies, fatal for the injector,
++// which mutates whatever it approves. The version token is what binary payloads
++// cannot fake by accident, so it is the part that matters. The loose check stays
++// as it is in bpf/common/http_types.h on purpose: tightening it there would
++// change the generic tracer's read-only view of unrelated traffic.
++//
++// Verified from the back: find the first CRLF, then demand SP "HTTP/1." DIGIT
++// immediately before it. The obvious shape — walk forward from the end of the
++// method token to the SP that closes the target — makes the loop start at one
++// of the seven method lengths, and the verifier then re-verifies all 512
++// iterations once per length. That is what pushed this program past the 1M
++// complexity limit ("processed 1000001 insns ... total_states 33575") and made
++// the whole sk_msg verdict fail to load. Scanning from a constant offset costs
++// one entry state instead of seven.
++//
++// The one thing this shape does not check is that the request-target holds no
++// SP; it still requires the version token to sit exactly before the *first*
++// CRLF in the message, which is the part opaque payloads cannot satisfy by
++// accident.
++static __always_inline bool http1_request_line_ok(const unsigned char *buf, u32 len) {
 +    if (len > k_http1_gate_scan_max) {
 +        len = k_http1_gate_scan_max;
 +    }
 +    if (len < k_http1_min_request_line) {
-+        return 0;
++        return false;
 +    }
 +
 +    const u32 target = http1_method_span(buf);
 +
 +    if (target == 0 || !is_http_request_target(buf[target & k_http1_gate_scan_mask])) {
-+        return 0;
++        return false;
 +    }
 +
-+    // The request-target ends at the next SP and may contain neither SP, CR nor
-+    // LF (RFC 9112 3.2), so a terminator reached before that SP disqualifies
-+    // the line.
-+    for (u32 i = target + 1; i < len; i++) {
-+        const unsigned char c = buf[i & k_http1_gate_scan_mask];
++    // The earliest a request line can end is right after the shortest possible
++    // one, "GET / HTTP/1.1\r\n", so the scan starts at its CR.
++    u32 cr = 0;
 +
-+        if (c == '\r' || c == '\n') {
-+            return 0;
-+        }
-+        if (c != ' ') {
-+            continue;
-+        }
-+        // The version token has to fit inside the bytes this message actually
-+        // refreshed, otherwise its absence proves nothing.
-+        if (i + k_http1_version_span >= len) {
-+            return 0;
-+        }
++    for (u32 i = k_http1_min_request_line - 2; i + 1 < len; i++) {
++        const unsigned char *p = &buf[i & k_http1_gate_scan_mask];
 +
-+        const unsigned char *v = &buf[(i + 1) & k_http1_gate_scan_mask];
-+
-+        if (v[0] != 'H' || v[1] != 'T' || v[2] != 'T' || v[3] != 'P' || v[4] != '/' ||
-+            v[5] != '1' || v[6] != '.' || v[7] < '0' || v[7] > '9' || v[8] != '\r' ||
-+            v[9] != '\n') {
-+            return 0;
++        // One OR-accumulated comparison and one branch, and the branch leaves
++        // the loop: the body has a single successor edge back to the loop head.
++        if (((u32)(p[0] ^ '\r') | (u32)(p[1] ^ '\n')) == 0) {
++            cr = i;
++            break;
 +        }
-+
-+        return i + k_http1_version_span + 1;
 +    }
 +
-+    return 0;
++    if (cr == 0) {
++        return false;
++    }
++
++    // cr is at least k_http1_min_request_line - 2, so this stays inside the
++    // bytes the method check already validated.
++    const unsigned char *v = &buf[(cr - k_http1_version_tail) & k_http1_gate_scan_mask];
++
++    // SP "HTTP/1." DIGIT, compared by OR-accumulating every mismatch into one
++    // word and taking a single branch. The SP is what separates the version
++    // token from the request-target, and a method byte can never match it, so
++    // no explicit check that the token sits past the method is needed.
++    const u32 mismatch = (u32)(v[0] ^ ' ') | (u32)(v[1] ^ 'H') | (u32)(v[2] ^ 'T') |
++                         (u32)(v[3] ^ 'T') | (u32)(v[4] ^ 'P') | (u32)(v[5] ^ '/') |
++                         (u32)(v[6] ^ '1') | (u32)(v[7] ^ '.') |
++                         (u32)((unsigned char)(v[8] - '0') > 9);
++
++    return mismatch == 0;
 +}
 +
-+// Case-insensitive search for an Upgrade request header, started at the CRLF
-+// that closed the request line so the first header field is covered too.
++// Case-insensitive search for an Upgrade request header. The scan starts at
++// offset 0: http1_request_line_ok has already established that the first CRLF
++// in the message terminates the request line, so the first field this examines
++// is the first header. A constant start also keeps the loop's entry state
++// single, which a caller-computed offset would not.
 +//
 +// This is the client half of the 101-response park above. The server's "101
 +// Switching Protocols" arrives on *ingress* and an sk_msg program only ever
@@ -208,64 +326,45 @@ index a5febb70..a8f24a14 100644
 +//
 +// Capped like the rest of the gate. An Upgrade field pushed past the cap by a
 +// large cookie leaves the socket unparked, but then every later message still
-+// has to satisfy http1_request_line_end before anything is mutated.
-+static __always_inline bool http1_request_upgrades(const unsigned char *buf, u32 len, u32 from) {
++// has to satisfy http1_request_line_ok before anything is mutated.
++static __always_inline bool http1_request_upgrades(const unsigned char *buf, u32 len) {
 +    if (len > k_http1_gate_scan_max) {
 +        len = k_http1_gate_scan_max;
 +    }
 +
-+    for (u32 i = from; i + k_http1_upgrade_span <= len; i++) {
++    for (u32 i = 0; i + k_http1_upgrade_span <= len; i++) {
 +        const unsigned char *p = &buf[i & k_http1_gate_scan_mask];
 +
-+        if (p[0] != '\r' || p[1] != '\n') {
-+            continue;
-+        }
-+        // Empty line: the header block is over and body bytes are not headers.
-+        if (p[2] == '\r' && p[3] == '\n') {
-+            return false;
-+        }
++        // Both tests OR-accumulate their mismatches into one word and take a
++        // single branch, and both branches leave the loop, so the body has one
++        // successor edge back to the loop head. Short-circuiting chains here
++        // multiplied verifier states per iteration until the entry program
++        // exceeded the 1M complexity limit and failed to load.
++        //
 +        // Field names are case-insensitive (RFC 9110 5.1); | 0x20 lowercases
 +        // ASCII letters, as http_types.h already does for the target byte.
-+        if ((p[2] | 0x20) == 'u' && (p[3] | 0x20) == 'p' && (p[4] | 0x20) == 'g' &&
-+            (p[5] | 0x20) == 'r' && (p[6] | 0x20) == 'a' && (p[7] | 0x20) == 'd' &&
-+            (p[8] | 0x20) == 'e' && p[9] == ':') {
++        const u32 crlf = (u32)(p[0] ^ '\r') | (u32)(p[1] ^ '\n');
++        const u32 name = (u32)((p[2] | 0x20) ^ 'u') | (u32)((p[3] | 0x20) ^ 'p') |
++                         (u32)((p[4] | 0x20) ^ 'g') | (u32)((p[5] | 0x20) ^ 'r') |
++                         (u32)((p[6] | 0x20) ^ 'a') | (u32)((p[7] | 0x20) ^ 'd') |
++                         (u32)((p[8] | 0x20) ^ 'e') | (u32)(p[9] ^ ':');
++
++        if ((crlf | name) == 0) {
 +            return true;
++        }
++        // Empty line: the header block is over and body bytes are not headers.
++        if ((crlf | (u32)(p[2] ^ '\r') | (u32)(p[3] ^ '\n')) == 0) {
++            return false;
 +        }
 +    }
 +
 +    return false;
 +}
 +
-+// The gate itself, over the scratch buffer fill_msg_buffers just refreshed.
-+// True when this message may be mutated as an HTTP/1 request; *upgrade is set
-+// when it is a request that asks to leave HTTP/1, which the caller turns into
-+// a permanent park instead of an injection.
-+static __always_inline bool http1_injectable_request(u32 msg_size, bool *upgrade) {
-+    *upgrade = false;
-+
-+    const unsigned char *buf = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
-+
-+    if (!buf) {
-+        return false;
-+    }
-+
-+    const u32 line_end = http1_request_line_end(buf, msg_size);
-+
-+    if (line_end == 0) {
-+        return false;
-+    }
-+
-+    // line_end is at least k_http1_min_request_line, so line_end - 2 lands on
-+    // the CR of the request line's own CRLF.
-+    *upgrade = http1_request_upgrades(buf, msg_size, line_end - 2);
-+
-+    return true;
-+}
-+
  #ifndef ENOMSG
  #define ENOMSG 42
  #endif
-@@ -1098,48 +1320,48 @@ int obi_packet_extender_sniff_h2(struct sk_msg_md *msg) {
+@@ -1098,48 +1351,48 @@ int obi_packet_extender_sniff_h2(struct sk_msg_md *msg) {
  }
  
  // HTTP/1 only. Caller must skip this for H2 sockets — connection-scoped tp_pid
@@ -340,7 +439,7 @@ index a5febb70..a8f24a14 100644
  }
  
  // Sock_msg program which detects packets where it should add space for
-@@ -1152,6 +1374,15 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1152,6 +1405,15 @@ int obi_packet_extender(struct sk_msg_md *msg) {
          return SK_PASS;
      }
  
@@ -356,7 +455,7 @@ index a5febb70..a8f24a14 100644
      // A connection that legally left HTTP/1 via 101 Switching Protocols
      // (kubectl port-forward SPDY/3.1, WebSockets) carries an opaque tunnel
      // from then on: injecting into tunneled bytes that merely resemble an
-@@ -1191,16 +1422,55 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1191,16 +1453,138 @@ int obi_packet_extender(struct sk_msg_md *msg) {
      t_ctx->h2_tp_retries = 0;
      t_ctx->go_grpc_conn = false;
  
@@ -376,26 +475,109 @@ index a5febb70..a8f24a14 100644
 +    // judge a previous message's bytes.
 +    const bool fresh_buffers = fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
 +
-+    // Default-deny. Every HTTP/1 mutation reachable from here — the TCP option
-+    // scheduled by handle_existing_tp_pid, the Traceparent splice, the trace
-+    // context created for either — now requires that this very message parses
-+    // as a complete HTTP/1 request line in those fresh bytes. Payload that
-+    // merely opens like a request, e.g. a binary frame starting "GET /" with
-+    // no version token behind it, is passed through untouched.
-+    bool upgrade_request = false;
-+    const bool http1_req =
-+        !h2_sock && fresh_buffers && http1_injectable_request(msg->size, &upgrade_request);
-+
-+    // The request asked to leave HTTP/1: park before injecting into it. The
-+    // upgrade request is the last HTTP/1 message on this socket, and its own
-+    // bytes are already part of a handshake the peer may be hashing, so it is
-+    // passed through as-is too.
-+    if (upgrade_request) {
-+        park_socket(msg);
-+        clear_tp_info_pid(&e_key);
++    // Default-deny. Every HTTP/1 mutation downstream — the TCP option scheduled
++    // by handle_existing_tp_pid, the Traceparent splice, the trace context
++    // created for either — requires that this very message parses as a complete
++    // HTTP/1 request line in those fresh bytes. Payload that merely opens like
++    // a request, e.g. a binary frame starting "GET /" with no version token
++    // behind it, is passed through untouched. The verdict is computed by the
++    // two gate programs below and lands in t_ctx->http1_req.
++    if (h2_sock || !fresh_buffers) {
++        t_ctx->http1_req = false;
++        bpf_tail_call_static(msg, &extender_jump_table, k_tail_http1_dispatch);
++        bpf_d_printk("tailcall failed [%s]", __FUNCTION__);
          return SK_PASS;
      }
  
++    bpf_tail_call_static(msg, &extender_jump_table, k_tail_http1_request_line);
++    bpf_d_printk("tailcall failed [%s]", __FUNCTION__);
++
++    return SK_PASS;
++}
++
++// Why the gate is three programs instead of three helper calls: each of the two
++// bounded scans leaves its loop holding one of k_http1_gate_scan_max *precise*
++// offsets, and the verifier keeps that precision, so everything downstream of a
++// scan is re-verified once per possible offset. Chaining two scans and the
++// dispatch inside one program multiplied those factors and blew the verifier's
++// per-program complexity limit outright — "processed 1000001 insns (limit
++// 1000000) ... total_states 28815" — which does not restrict injection, it
++// makes the whole sk_msg verdict fail to load and disables the injector
++// silently. A tail call ends the program, so each scan's fan-out reaches only
++// the handful of instructions after it. Upstream splits detect_h2 and
++// validate_h2_tp out for the same reason, and find_existing_tp scans 1KB per
++// program on exactly this pattern.
++//
++// k_tail_http1_request_line — strict HTTP/1 request-line parse of this message.
++SEC("sk_msg")
++int obi_packet_extender_http1_request_line(struct sk_msg_md *msg) {
++    tailcall_ctx *t_ctx = tailcall_ctx_mem();
++
++    if (!t_ctx) {
++        return SK_PASS;
++    }
++
++    const unsigned char *buf = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
++
++    t_ctx->http1_req = buf && http1_request_line_ok(buf, msg->size);
++
++    if (!t_ctx->http1_req) {
++        bpf_tail_call_static(msg, &extender_jump_table, k_tail_http1_dispatch);
++        bpf_d_printk("tailcall failed [%s]", __FUNCTION__);
++        return SK_PASS;
++    }
++
++    bpf_tail_call_static(msg, &extender_jump_table, k_tail_http1_upgrade);
++    bpf_d_printk("tailcall failed [%s]", __FUNCTION__);
++
++    return SK_PASS;
++}
++
++// k_tail_http1_upgrade — the message is a request; park the socket if it asks
++// to leave HTTP/1 rather than inject into it. The upgrade request is the last
++// HTTP/1 message on this socket, and its own bytes are already part of a
++// handshake the peer may be hashing, so it is passed through as-is too.
++SEC("sk_msg")
++int obi_packet_extender_http1_upgrade(struct sk_msg_md *msg) {
++    tailcall_ctx *t_ctx = tailcall_ctx_mem();
++
++    if (!t_ctx) {
++        return SK_PASS;
++    }
++
++    const unsigned char *buf = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
++
++    if (buf && http1_request_upgrades(buf, msg->size)) {
++        park_socket(msg);
++        clear_tp_info_pid(&t_ctx->e_key);
++        return SK_PASS;
++    }
++
++    bpf_tail_call_static(msg, &extender_jump_table, k_tail_http1_dispatch);
++    bpf_d_printk("tailcall failed [%s]", __FUNCTION__);
++
++    return SK_PASS;
++}
++
++// k_tail_http1_dispatch — everything the default-deny gate guards. Reached only
++// for an unparked socket, with the current message already pulled, the scratch
++// buffer already filled, and the gate's verdict in t_ctx->http1_req.
++SEC("sk_msg")
++int obi_packet_extender_http1_dispatch(struct sk_msg_md *msg) {
++    tailcall_ctx *t_ctx = tailcall_ctx_mem();
++
++    if (!t_ctx) {
++        return SK_PASS;
++    }
++
++    // Same task and same socket as the entry program, so both are re-derived
++    // rather than threaded through the scratch struct.
++    const u64 id = bpf_get_current_pid_tgid();
++    const connection_info_t conn = get_connection_info(msg);
++    const egress_key_t e_key = t_ctx->e_key;
++    const bool http1_req = t_ctx->http1_req;
++    const bool h2_sock = is_h2_socket(msg);
++
 +    // skip H2 here — it uses HPACK for per-stream traceparents
 +    tp_info_pid_t *tp_pid = get_tp_info_pid(&e_key);
 +    if (tp_pid && !h2_sock) {
@@ -414,11 +596,11 @@ index a5febb70..a8f24a14 100644
      if (is_go_grpc_client_conn(&t_ctx->p_conn)) {
 -        bpf_msg_pull_data(msg, 0, msg->size, 0);
 -        fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
-+        // already pulled and filled above
++        // already pulled and filled by the entry program
          // per-stream decision in the h2 chain: inject only streams the uprobe left written=0
          t_ctx->go_grpc_conn = true;
          bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
-@@ -1211,13 +1481,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1211,13 +1595,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
          return SK_PASS;
      }
  
@@ -433,7 +615,7 @@ index a5febb70..a8f24a14 100644
          bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
          return SK_PASS;
      }
-@@ -1230,7 +1494,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1230,7 +1608,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
      bpf_dbg_printk("MSG TO=%llx:%d", conn.d_ip[3], conn.d_port);
      bpf_dbg_printk("MSG SIZE=%u", msg->size);
  
@@ -442,3 +624,11 @@ index a5febb70..a8f24a14 100644
      if (is_http) {
          bpf_dbg_printk("len=%d, s_port=%d", msg->size, msg->local_port);
          init_tp_ctx_parent_tp(t_ctx);
+@@ -1239,6 +1617,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+     }
+ 
+     wrap_http2_traceparent(msg, &t_ctx->p_conn);
++
+     return SK_PASS;
+ }
+ 

--- a/ebpf/patches/obi/010-default-deny-injection-gate.patch
+++ b/ebpf/patches/obi/010-default-deny-injection-gate.patch
@@ -1,0 +1,444 @@
+diff --git a/bpf/tpinjector/maps/sk_inject_gate.h b/bpf/tpinjector/maps/sk_inject_gate.h
+new file mode 100644
+index 00000000..da2ac5fd
+--- /dev/null
++++ b/bpf/tpinjector/maps/sk_inject_gate.h
+@@ -0,0 +1,21 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++// Per-socket verdict of the default-deny injection gate: 0 unknown, 1 parked.
++//
++// Deliberately separate storage from sk_h2_conn_flag: that byte drives the
++// HTTP/2 preface state machine and every dispatch site reads it as an HTTP/2
++// state, so an HTTP/1 verdict folded into its enum would make those reads lie.
++// SK_STORAGE is socket-lifetime state, freed by the kernel when the socket is
++// closed, which is exactly the scope of a "this connection left HTTP/1" fact.
++struct {
++    __uint(type, BPF_MAP_TYPE_SK_STORAGE);
++    __uint(map_flags, BPF_F_NO_PREALLOC);
++    __type(key, u32);
++    __type(value, u8);
++} sk_inject_gate SEC(".maps");
+diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
+index a5febb70..a8f24a14 100644
+--- a/bpf/tpinjector/tpinjector.c
++++ b/bpf/tpinjector/tpinjector.c
+@@ -45,6 +45,7 @@
+ #include <tpinjector/inject_policy.h>
+ #include <tpinjector/maps/sk_h2_flags.h>
+ #include <tpinjector/maps/sk_h2_conn_flag.h>
++#include <tpinjector/maps/sk_inject_gate.h>
+ #include <tpinjector/maps/sk_tp_info_pid_map.h>
+ 
+ char __license[] SEC("license") = "Dual MIT/GPL";
+@@ -343,6 +344,227 @@ static __always_inline bool http1_upgrade_completed(struct sk_msg_md *msg) {
+     return is_http1_101_response(msg->data, msg->data_end);
+ }
+ 
++// =============================================================================
++// Default-deny HTTP/1 injection gate
++// =============================================================================
++//
++// Per-socket verdict recorded in sk_inject_gate. Parking is permanent: it
++// states that the bytes on this socket are no longer HTTP/1, and nothing on a
++// TCP stream ever takes that back.
++enum {
++    k_inject_gate_unknown = 0, // nothing decided yet
++    k_inject_gate_parked = 1,  // never mutate another byte on this socket
++};
++
++static __always_inline bool sock_is_parked(struct sk_msg_md *msg) {
++    struct bpf_sock *sk = msg->sk;
++
++    // Without a socket there is nowhere to record a verdict, so a park
++    // decided on an earlier message could not have survived to this one.
++    // Default-deny has to fail closed here rather than inject blind; in
++    // practice sk_msg always carries its socket, and the H2 state machine,
++    // schedule_write_tcp_option and set_h2_sock_state all give up on !sk
++    // anyway, so nothing that could inject is lost.
++    if (!sk) {
++        return true;
++    }
++
++    const u8 *gate = bpf_sk_storage_get(&sk_inject_gate, sk, NULL, 0);
++
++    return gate && *gate == k_inject_gate_parked;
++}
++
++static __always_inline void park_socket(struct sk_msg_md *msg) {
++    struct bpf_sock *sk = msg->sk;
++
++    if (!sk) {
++        return;
++    }
++
++    u8 init = k_inject_gate_parked;
++    u8 *gate = bpf_sk_storage_get(&sk_inject_gate, sk, &init, BPF_SK_STORAGE_GET_F_CREATE);
++
++    if (gate) {
++        *gate = k_inject_gate_parked;
++    }
++}
++
++enum {
++    // Bytes of a message the gate is willing to read. fill_msg_buffers
++    // refreshes min(msg->size, k_msg_buffer_size_max) scratch bytes from *this*
++    // message, so the scan is also clamped to msg->size: past it lie either
++    // out-of-message kernel bytes or the tail of a previous message. Power of
++    // two so the index mask keeps every access provably inside the map value.
++    k_http1_gate_scan_max = 512,
++    k_http1_gate_scan_mask = k_http1_gate_scan_max - 1,
++    // "GET / HTTP/1.1\r\n" — the shortest request line that can exist.
++    k_http1_min_request_line = 16,
++    // What the SP after the request-target must be followed by:
++    // "HTTP/1." DIGIT CR LF.
++    k_http1_version_span = 10,
++    // "\r\nupgrade:"
++    k_http1_upgrade_span = 10,
++};
++
++_Static_assert((k_http1_gate_scan_max & (k_http1_gate_scan_max - 1)) == 0,
++               "k_http1_gate_scan_max must be a power of 2");
++_Static_assert(k_http1_gate_scan_max <= k_msg_buffer_size_max,
++               "the gate must not read past what fill_msg_buffers refreshes");
++
++// Length of the method token including its single trailing SP, 0 when the
++// buffer does not open with a method the injector recognises. The method set
++// mirrors is_http_request_buf (bpf/common/http_types.h) so the gate can only
++// ever narrow what upstream calls HTTP/1, never widen it.
++static __always_inline u32 http1_method_span(const unsigned char *p) {
++    if (__builtin_memcmp(p, "GET ", 4) == 0 || __builtin_memcmp(p, "PUT ", 4) == 0) {
++        return 4;
++    }
++    if (__builtin_memcmp(p, "POST ", 5) == 0 || __builtin_memcmp(p, "HEAD ", 5) == 0) {
++        return 5;
++    }
++    if (__builtin_memcmp(p, "PATCH ", 6) == 0) {
++        return 6;
++    }
++    if (__builtin_memcmp(p, "DELETE ", 7) == 0) {
++        return 7;
++    }
++    if (__builtin_memcmp(p, "OPTIONS ", 8) == 0) {
++        return 8;
++    }
++
++    return 0;
++}
++
++// A complete RFC 9112 3.1 request line at offset 0:
++//
++//     method SP request-target SP "HTTP/1." DIGIT CRLF
++//
++// Returns the offset just past the CRLF, 0 when the bytes are not a request
++// line. is_http_request_buf accepts a method prefix plus one target byte and
++// nothing else, so any framing whose payload happens to open "GET /" passes
++// it — harmless for generictracer, which only classifies, fatal for the
++// injector, which mutates whatever it approves. The version token is what
++// binary payloads cannot fake by accident, so it is the part that matters.
++// The loose check stays as it is in bpf/common/http_types.h on purpose:
++// tightening it there would change the generic tracer's read-only view of
++// unrelated traffic.
++static __always_inline u32 http1_request_line_end(const unsigned char *buf, u32 len) {
++    if (len > k_http1_gate_scan_max) {
++        len = k_http1_gate_scan_max;
++    }
++    if (len < k_http1_min_request_line) {
++        return 0;
++    }
++
++    const u32 target = http1_method_span(buf);
++
++    if (target == 0 || !is_http_request_target(buf[target & k_http1_gate_scan_mask])) {
++        return 0;
++    }
++
++    // The request-target ends at the next SP and may contain neither SP, CR nor
++    // LF (RFC 9112 3.2), so a terminator reached before that SP disqualifies
++    // the line.
++    for (u32 i = target + 1; i < len; i++) {
++        const unsigned char c = buf[i & k_http1_gate_scan_mask];
++
++        if (c == '\r' || c == '\n') {
++            return 0;
++        }
++        if (c != ' ') {
++            continue;
++        }
++        // The version token has to fit inside the bytes this message actually
++        // refreshed, otherwise its absence proves nothing.
++        if (i + k_http1_version_span >= len) {
++            return 0;
++        }
++
++        const unsigned char *v = &buf[(i + 1) & k_http1_gate_scan_mask];
++
++        if (v[0] != 'H' || v[1] != 'T' || v[2] != 'T' || v[3] != 'P' || v[4] != '/' ||
++            v[5] != '1' || v[6] != '.' || v[7] < '0' || v[7] > '9' || v[8] != '\r' ||
++            v[9] != '\n') {
++            return 0;
++        }
++
++        return i + k_http1_version_span + 1;
++    }
++
++    return 0;
++}
++
++// Case-insensitive search for an Upgrade request header, started at the CRLF
++// that closed the request line so the first header field is covered too.
++//
++// This is the client half of the 101-response park above. The server's "101
++// Switching Protocols" arrives on *ingress* and an sk_msg program only ever
++// sees egress, so on a client socket the upgrade request is the only warning
++// there is. tailscaled's control channel ("Upgrade: tailscale-control-protocol",
++// then Noise), its DERP client ("Upgrade: DERP", then type/length binary
++// frames) and every WebSocket client have exactly this shape: one HTTP/1
++// request out, then bytes that belong to a different protocol. Whether the
++// server accepted the upgrade is unknowable from egress, so a socket that
++// merely asks is parked: the cost of a refused upgrade is lost propagation,
++// the cost of guessing wrong the other way is a traceparent spliced into
++// tunnelled bytes, shifting their framing for good.
++//
++// Capped like the rest of the gate. An Upgrade field pushed past the cap by a
++// large cookie leaves the socket unparked, but then every later message still
++// has to satisfy http1_request_line_end before anything is mutated.
++static __always_inline bool http1_request_upgrades(const unsigned char *buf, u32 len, u32 from) {
++    if (len > k_http1_gate_scan_max) {
++        len = k_http1_gate_scan_max;
++    }
++
++    for (u32 i = from; i + k_http1_upgrade_span <= len; i++) {
++        const unsigned char *p = &buf[i & k_http1_gate_scan_mask];
++
++        if (p[0] != '\r' || p[1] != '\n') {
++            continue;
++        }
++        // Empty line: the header block is over and body bytes are not headers.
++        if (p[2] == '\r' && p[3] == '\n') {
++            return false;
++        }
++        // Field names are case-insensitive (RFC 9110 5.1); | 0x20 lowercases
++        // ASCII letters, as http_types.h already does for the target byte.
++        if ((p[2] | 0x20) == 'u' && (p[3] | 0x20) == 'p' && (p[4] | 0x20) == 'g' &&
++            (p[5] | 0x20) == 'r' && (p[6] | 0x20) == 'a' && (p[7] | 0x20) == 'd' &&
++            (p[8] | 0x20) == 'e' && p[9] == ':') {
++            return true;
++        }
++    }
++
++    return false;
++}
++
++// The gate itself, over the scratch buffer fill_msg_buffers just refreshed.
++// True when this message may be mutated as an HTTP/1 request; *upgrade is set
++// when it is a request that asks to leave HTTP/1, which the caller turns into
++// a permanent park instead of an injection.
++static __always_inline bool http1_injectable_request(u32 msg_size, bool *upgrade) {
++    *upgrade = false;
++
++    const unsigned char *buf = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
++
++    if (!buf) {
++        return false;
++    }
++
++    const u32 line_end = http1_request_line_end(buf, msg_size);
++
++    if (line_end == 0) {
++        return false;
++    }
++
++    // line_end is at least k_http1_min_request_line, so line_end - 2 lands on
++    // the CR of the request line's own CRLF.
++    *upgrade = http1_request_upgrades(buf, msg_size, line_end - 2);
++
++    return true;
++}
++
+ #ifndef ENOMSG
+ #define ENOMSG 42
+ #endif
+@@ -1098,48 +1320,48 @@ int obi_packet_extender_sniff_h2(struct sk_msg_md *msg) {
+ }
+ 
+ // HTTP/1 only. Caller must skip this for H2 sockets — connection-scoped tp_pid
+-// carries the wrong context for multiplexed streams.
++// carries the wrong context for multiplexed streams — and must have passed the
++// default-deny gate first: the message is then known to be a complete HTTP/1
++// request in a freshly filled scratch buffer, which is the precondition of
++// both mutations below.
++//
++// Upstream scheduled the TCP option as this function's very first statement,
++// ahead of the validity, freshness and payload checks. A message that turned
++// out not to be HTTP could therefore already have put an option on the wire
++// that nothing further down could take back, so the ordering is inverted here:
++// every check first, mutations last. The 009 clear-on-stale semantics are
++// preserved, the caller now owns the fill and clears the pending context when
++// it comes back stale.
+ static __always_inline bool handle_existing_tp_pid(struct sk_msg_md *msg,
+                                                    u64 id,
+                                                    const pid_connection_info_t *p_conn,
+                                                    const egress_key_t *e_key,
+                                                    tp_info_pid_t *tp_pid) {
+-    if (inject_flags & k_inject_tcp_options) {
+-        schedule_write_tcp_option(msg, tp_pid);
+-    }
+-
+     // valid==0: SSL or junk — drop it and stop tracking
+     if (tp_pid->valid == 0) {
+         clear_tp_info_pid(e_key);
+         return true;
+     }
+ 
+-    bpf_msg_pull_data(msg, 0, msg->size, 0);
+-
+-    // If the scratch buffer wasn't refreshed from *this* message (SSL
+-    // payload, empty message, or allocation failure), protocol_detector
+-    // would judge stale bytes left by a previous message on this CPU. A
+-    // stale plaintext HTTP request start would make it approve injecting
+-    // into what is actually opaque data (e.g. TLS ciphertext, which the
+-    // splice would corrupt into a peer-side bad_record_mac). Never detect
+-    // or inject on a stale buffer.
+-    if (!fill_msg_buffers(msg, p_conn, e_key)) {
++    // Still needed next to the gate: protocol_detector also refuses a
++    // connection that already has a request in flight (already_tracked), which
++    // is what keeps a single connection from being extended twice.
++    if (!protocol_detector(msg, id, &p_conn->conn)) {
+         clear_tp_info_pid(e_key);
+-        return true;
++        return false;
+     }
+ 
+-    const bool is_http = protocol_detector(msg, id, &p_conn->conn);
+-    if (is_http) {
+-        if (inject_flags & k_inject_http_headers) {
+-            write_http_traceparent(msg, tp_pid);
+-        } else {
+-            clear_tp_info_pid(e_key);
+-        }
+-        return true;
++    if (inject_flags & k_inject_tcp_options) {
++        schedule_write_tcp_option(msg, tp_pid);
+     }
+ 
+-    clear_tp_info_pid(e_key);
+-    return false;
++    if (inject_flags & k_inject_http_headers) {
++        write_http_traceparent(msg, tp_pid);
++    } else {
++        clear_tp_info_pid(e_key);
++    }
++
++    return true;
+ }
+ 
+ // Sock_msg program which detects packets where it should add space for
+@@ -1152,6 +1374,15 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+         return SK_PASS;
+     }
+ 
++    // Default-deny entry gate. A parked socket is never mutated again, and the
++    // check sits ahead of everything: ahead of get_tp_info_pid /
++    // handle_existing_tp_pid so a leftover trace context cannot resurrect
++    // injection, and ahead of the protocol_detector route so no byte of a
++    // parked stream is even classified.
++    if (sock_is_parked(msg)) {
++        return SK_PASS;
++    }
++
+     // A connection that legally left HTTP/1 via 101 Switching Protocols
+     // (kubectl port-forward SPDY/3.1, WebSockets) carries an opaque tunnel
+     // from then on: injecting into tunneled bytes that merely resemble an
+@@ -1191,16 +1422,55 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+     t_ctx->h2_tp_retries = 0;
+     t_ctx->go_grpc_conn = false;
+ 
+-    // skip H2 here — it uses HPACK for per-stream traceparents
+-    tp_info_pid_t *tp_pid = get_tp_info_pid(&e_key);
+-    if (tp_pid && !is_h2_socket(msg) &&
+-        handle_existing_tp_pid(msg, id, &t_ctx->p_conn, &e_key, tp_pid)) {
++    // Confirmed and scanning HTTP/2 sockets keep their own chain: HPACK
++    // injection is already default-deny (h2_inject_verdict) and an H2 frame is
++    // not an HTTP/1 request, so the HTTP/1 gate must never judge one. Read
++    // once, the state cannot change inside this program.
++    const bool h2_sock = is_h2_socket(msg);
++
++    bpf_msg_pull_data(msg, 0, msg->size, 0);
++    // 009: a scratch buffer that wasn't refreshed from *this* message (SSL
++    // payload, empty message, allocation failure) would make everything below
++    // judge a previous message's bytes.
++    const bool fresh_buffers = fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
++
++    // Default-deny. Every HTTP/1 mutation reachable from here — the TCP option
++    // scheduled by handle_existing_tp_pid, the Traceparent splice, the trace
++    // context created for either — now requires that this very message parses
++    // as a complete HTTP/1 request line in those fresh bytes. Payload that
++    // merely opens like a request, e.g. a binary frame starting "GET /" with
++    // no version token behind it, is passed through untouched.
++    bool upgrade_request = false;
++    const bool http1_req =
++        !h2_sock && fresh_buffers && http1_injectable_request(msg->size, &upgrade_request);
++
++    // The request asked to leave HTTP/1: park before injecting into it. The
++    // upgrade request is the last HTTP/1 message on this socket, and its own
++    // bytes are already part of a handshake the peer may be hashing, so it is
++    // passed through as-is too.
++    if (upgrade_request) {
++        park_socket(msg);
++        clear_tp_info_pid(&e_key);
+         return SK_PASS;
+     }
+ 
++    // skip H2 here — it uses HPACK for per-stream traceparents
++    tp_info_pid_t *tp_pid = get_tp_info_pid(&e_key);
++    if (tp_pid && !h2_sock) {
++        if (!http1_req) {
++            // Upstream entered handle_existing_tp_pid at this point and
++            // scheduled a TCP option before reading a single payload byte.
++            // Default-deny drops the pending context instead — which is also
++            // 009's clear-on-stale behaviour, now covering every reason the
++            // gate can refuse.
++            clear_tp_info_pid(&e_key);
++        } else if (handle_existing_tp_pid(msg, id, &t_ctx->p_conn, &e_key, tp_pid)) {
++            return SK_PASS;
++        }
++    }
++
+     if (is_go_grpc_client_conn(&t_ctx->p_conn)) {
+-        bpf_msg_pull_data(msg, 0, msg->size, 0);
+-        fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
++        // already pulled and filled above
+         // per-stream decision in the h2 chain: inject only streams the uprobe left written=0
+         t_ctx->go_grpc_conn = true;
+         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
+@@ -1211,13 +1481,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+         return SK_PASS;
+     }
+ 
+-    bpf_msg_pull_data(msg, 0, msg->size, 0);
+-    // See handle_existing_tp_pid: a stale scratch buffer must never reach
+-    // protocol_detector. H2 handling below is unaffected, it reads the
+-    // message directly and has its own SSL guards.
+-    const bool fresh_buffers = fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
+-
+-    if (is_h2_socket(msg)) {
++    if (h2_sock) {
+         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
+         return SK_PASS;
+     }
+@@ -1230,7 +1494,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+     bpf_dbg_printk("MSG TO=%llx:%d", conn.d_ip[3], conn.d_port);
+     bpf_dbg_printk("MSG SIZE=%u", msg->size);
+ 
+-    const bool is_http = fresh_buffers && protocol_detector(msg, id, &conn);
++    const bool is_http = http1_req && protocol_detector(msg, id, &conn);
+     if (is_http) {
+         bpf_dbg_printk("len=%d, s_port=%d", msg->size, msg->local_port);
+         init_tp_ctx_parent_tp(t_ctx);

--- a/ebpf/patches/obi/011-valid-pid-first.patch
+++ b/ebpf/patches/obi/011-valid-pid-first.patch
@@ -1,0 +1,79 @@
+diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
+index a8f24a14..fe56c360 100644
+--- a/bpf/tpinjector/tpinjector.c
++++ b/bpf/tpinjector/tpinjector.c
+@@ -1374,6 +1374,38 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+         return SK_PASS;
+     }
+ 
++    const u64 id = bpf_get_current_pid_tgid();
++
++    // Discovery filter, hoisted to the entry. Upstream tested it only on the
++    // fall-through route, so the existing-trace route (get_tp_info_pid /
++    // handle_existing_tp_pid) and the Go-gRPC coordination route both mutated
++    // messages of processes OBI was never asked to instrument. Nothing below
++    // may touch a byte before this passes.
++    //
++    // What it reads: pid_matches() against the `valid_pids` bitmap, memoised in
++    // `pid_cache` (bpf/pid/pid.h). Both maps are OBI_PIN_INTERNAL and are
++    // filled by the userspace discovery loop, rebuildValidPids() in
++    // pkg/internal/ebpf/generictracer/generictracer.go, so the allow-list here
++    // is exactly the set of instrumented executables. With
++    // OTEL_EBPF_BPF_PID_FILTER_OFF (`filter_pids == 0`) it degrades to
++    // "return the tgid", i.e. everything passes, matching the rest of OBI.
++    //
++    // Context: sk_msg runs from tcp_bpf_sendmsg in the sending task's syscall
++    // context, so bpf_get_current_pid_tgid() is the sender. Every unknown
++    // context resolves in the deny direction — a kthread or tgid 0 yields 0
++    // and returns here — which skips injection and can never corrupt: this
++    // program's only mutations are reached further down.
++    //
++    // Consequence of sitting above the park bookkeeping: an excluded pid's
++    // upgrade request no longer parks the socket. That is safe because an
++    // excluded pid cannot mutate anything either, and a socket written by both
++    // an excluded and an included process (or one discovered only after its
++    // upgrade request went out) falls back on the strict request-line gate,
++    // which post-upgrade tunnel bytes have to pass before anything is spliced.
++    if (!valid_pid(id)) {
++        return SK_PASS;
++    }
++
+     // Default-deny entry gate. A parked socket is never mutated again, and the
+     // check sits ahead of everything: ahead of get_tp_info_pid /
+     // handle_existing_tp_pid so a leftover trace context cannot resurrect
+@@ -1408,7 +1440,6 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+         return SK_PASS;
+     }
+ 
+-    const u64 id = bpf_get_current_pid_tgid();
+     const connection_info_t conn = get_connection_info(msg);
+     const egress_key_t e_key = make_egress_key(&conn);
+ 
+@@ -1469,6 +1500,16 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+         }
+     }
+ 
++    // The Go-gRPC coordination route now sits behind the entry filter too. For
++    // an allowed pid this is a no-op: valid_pid passed, so control flow reaches
++    // here exactly as before. For an excluded pid the tail call no longer runs,
++    // and that direction can only remove injections, never duplicate them: the
++    // coordination this route implements is the *uprobe* telling sk_msg which
++    // streams it already wrote (`tp_p->written = 1`, bpf/gotracer/go_grpc.c:983
++    // "confirm so sk_msg skips this stream"), so sk_msg is the second writer,
++    // not the first. Not running it drops a would-be injection; the uprobe's
++    // own write is untouched, and every remaining stream is still refused by
++    // h2_inject_verdict rather than injected twice.
+     if (is_go_grpc_client_conn(&t_ctx->p_conn)) {
+         // already pulled and filled above
+         // per-stream decision in the h2 chain: inject only streams the uprobe left written=0
+@@ -1477,10 +1518,6 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+         return SK_PASS;
+     }
+ 
+-    if (!valid_pid(id)) {
+-        return SK_PASS;
+-    }
+-
+     if (h2_sock) {
+         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
+         return SK_PASS;

--- a/ebpf/patches/obi/011-valid-pid-first.patch
+++ b/ebpf/patches/obi/011-valid-pid-first.patch
@@ -1,8 +1,27 @@
 diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
-index a8f24a14..fe56c360 100644
+index c6dcdbbc..078c160f 100644
 --- a/bpf/tpinjector/tpinjector.c
 +++ b/bpf/tpinjector/tpinjector.c
-@@ -1374,6 +1374,38 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -56,6 +56,9 @@ char __license[] SEC("license") = "Dual MIT/GPL";
+ //
+ //   obi_packet_extender (sk_msg entry)
+ //   │
++//   ├── !valid_pid → SK_PASS           │  Unmonitored process — nothing below
++//   │                                  │  may touch a byte of its traffic
++//   │                                  │
+ //   ├── socket parked → SK_PASS        │  Default-deny: this stream left
+ //   │                                  │  HTTP/1, never touch it again
+ //   ├── pull_data + fill_msg_buffers   │  Committed to processing
+@@ -89,8 +92,6 @@ char __license[] SEC("license") = "Dual MIT/GPL";
+ //   │     └── detect_h2                │  streams whose stored tp has
+ //   │                                  │  written=0 (uprobe miss)
+ //   │                                  │
+-//   ├── !valid_pid → SK_PASS           │  Unmonitored process
+-//   │                                  │
+ //   ├── is_h2_socket?                  │  Preface seen / confirmed H2: skip
+ //   │     └─ tail-call detect_h2       │  preface check, drive the H2 chain
+ //   │                                 │
+@@ -1405,6 +1406,38 @@ int obi_packet_extender(struct sk_msg_md *msg) {
          return SK_PASS;
      }
  
@@ -41,7 +60,7 @@ index a8f24a14..fe56c360 100644
      // Default-deny entry gate. A parked socket is never mutated again, and the
      // check sits ahead of everything: ahead of get_tp_info_pid /
      // handle_existing_tp_pid so a leftover trace context cannot resurrect
-@@ -1408,7 +1440,6 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1439,7 +1472,6 @@ int obi_packet_extender(struct sk_msg_md *msg) {
          return SK_PASS;
      }
  
@@ -49,24 +68,24 @@ index a8f24a14..fe56c360 100644
      const connection_info_t conn = get_connection_info(msg);
      const egress_key_t e_key = make_egress_key(&conn);
  
-@@ -1469,6 +1500,16 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1583,6 +1615,16 @@ int obi_packet_extender_http1_dispatch(struct sk_msg_md *msg) {
          }
      }
  
 +    // The Go-gRPC coordination route now sits behind the entry filter too. For
 +    // an allowed pid this is a no-op: valid_pid passed, so control flow reaches
-+    // here exactly as before. For an excluded pid the tail call no longer runs,
-+    // and that direction can only remove injections, never duplicate them: the
-+    // coordination this route implements is the *uprobe* telling sk_msg which
-+    // streams it already wrote (`tp_p->written = 1`, bpf/gotracer/go_grpc.c:983
++    // here exactly as before. For an excluded pid the route no longer runs, and
++    // that direction can only remove injections, never duplicate them: the
++    // coordination it implements is the *uprobe* telling sk_msg which streams
++    // it already wrote (`tp_p->written = 1`, bpf/gotracer/go_grpc.c:983
 +    // "confirm so sk_msg skips this stream"), so sk_msg is the second writer,
 +    // not the first. Not running it drops a would-be injection; the uprobe's
 +    // own write is untouched, and every remaining stream is still refused by
 +    // h2_inject_verdict rather than injected twice.
      if (is_go_grpc_client_conn(&t_ctx->p_conn)) {
-         // already pulled and filled above
+         // already pulled and filled by the entry program
          // per-stream decision in the h2 chain: inject only streams the uprobe left written=0
-@@ -1477,10 +1518,6 @@ int obi_packet_extender(struct sk_msg_md *msg) {
+@@ -1591,10 +1633,6 @@ int obi_packet_extender_http1_dispatch(struct sk_msg_md *msg) {
          return SK_PASS;
      }
  

--- a/ebpf/patches/obi/012-discovery-scoped-sockhash.patch
+++ b/ebpf/patches/obi/012-discovery-scoped-sockhash.patch
@@ -30,38 +30,6 @@ index 0000000..39144e5
 +    __type(key, u64);
 +    __type(value, u8);
 +} iter_allowed_socks SEC(".maps");
-diff --git a/bpf/tpinjector/maps/sk_discovery_ok.h b/bpf/tpinjector/maps/sk_discovery_ok.h
-new file mode 100644
-index 0000000..b6737fd
---- /dev/null
-+++ b/bpf/tpinjector/maps/sk_discovery_ok.h
-@@ -0,0 +1,26 @@
-+// Copyright The OpenTelemetry Authors
-+// SPDX-License-Identifier: Apache-2.0
-+
-+#pragma once
-+
-+#include <bpfcore/vmlinux.h>
-+#include <bpfcore/bpf_helpers.h>
-+
-+// "The task that opened this socket passed OBI's discovery filter."
-+//
-+// Written at BPF_SOCK_OPS_TCP_CONNECT_CB, which is the one sock_ops event on
-+// an outgoing connection that runs in the connecting task's own context, and
-+// read at BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB, which does not. Absence means
-+// "not known to be instrumented" and is the deny answer, so a socket whose
-+// connect callback never ran (kernel-internal sockets, MPTCP subflows dialled
-+// from a workqueue, sockets opened before OBI attached) is left alone.
-+//
-+// SK_STORAGE rather than a cookie-keyed hash: the fact is socket-lifetime, the
-+// kernel frees it on close, and neither writer nor reader has to agree on a
-+// key. One byte per outgoing socket in the instrumented cgroup.
-+struct {
-+    __uint(type, BPF_MAP_TYPE_SK_STORAGE);
-+    __uint(map_flags, BPF_F_NO_PREALLOC);
-+    __type(key, u32);
-+    __type(value, u8);
-+} sk_discovery_ok SEC(".maps");
 diff --git a/bpf/tpinjector/sock_iter.c b/bpf/tpinjector/sock_iter.c
 index 5585597..48889d0 100644
 --- a/bpf/tpinjector/sock_iter.c
@@ -102,18 +70,18 @@ index 5585597..48889d0 100644
  
      char src_buf[k_addr_buf_len] = {};
 diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
-index 078c160..1008e20 100644
+index 078c160..06395ec 100644
 --- a/bpf/tpinjector/tpinjector.c
 +++ b/bpf/tpinjector/tpinjector.c
-@@ -43,6 +43,7 @@
+@@ -36,6 +36,7 @@
+ #include <maps/msg_buffers.h>
+ #include <maps/outgoing_trace_map.h>
+ #include <maps/sock_dir.h>
++#include <maps/sock_pids.h>
+ #include <maps/tp_info_mem.h>
+ #include <maps/tracked_sock_cookies.h>
  
- #include <tpinjector/h2_parse.h>
- #include <tpinjector/inject_policy.h>
-+#include <tpinjector/maps/sk_discovery_ok.h>
- #include <tpinjector/maps/sk_h2_flags.h>
- #include <tpinjector/maps/sk_h2_conn_flag.h>
- #include <tpinjector/maps/sk_inject_gate.h>
-@@ -799,8 +800,83 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
+@@ -799,8 +800,90 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
      bpf_sock_ops_cb_flags_set(skops, skops->bpf_sock_ops_cb_flags | flags);
  }
  
@@ -133,20 +101,33 @@ index 078c160..1008e20 100644
 +// BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB is raised by tcp_finish_connect() ->
 +// tcp_init_transfer() (net/ipv4/tcp_input.c) while the SYN-ACK is processed.
 +// Unless the socket happened to be owned by the connecting task at that
-+// moment, that is NET_RX softirq on whichever CPU took the packet, so
-+// bpf_get_current_pid_tgid() returns the interrupted task — an unrelated
-+// process, or 0 for the idle task. Testing valid_pid() there would deny
-+// instrumented processes at random, which is worse than the bug.
-+// BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB is further removed still: it fires for a
-+// child socket that no task has returned from accept() yet.
++// moment, that is NET_RX softirq on whichever CPU took the packet, so the
++// current task is the interrupted one — an unrelated process, or 0 for the
++// idle task. Deciding discovery there would deny instrumented processes at
++// random, which is worse than the bug. BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB is
++// further removed still: it fires for a child socket that no task has returned
++// from accept() yet. sock_ops cannot even ask: bpf_get_current_pid_tgid()
++// reaches BPF_PROG_TYPE_SOCK_OPS only through bpf_base_func_proto(), and it was
++// not added there until v6.10 (Yonghong Song, "bpf: Allow
++// bpf_get_[ns_]current_pid_tgid() in all program types"). On 5.15 the program
++// does not load at all: "unknown func bpf_get_current_pid_tgid#14".
 +//
-+// BPF_SOCK_OPS_TCP_CONNECT_CB does not have that problem. It is raised from
-+// the first line of tcp_connect() (net/ipv4/tcp_output.c), reached only via
-+// sk_prot->connect from the connect(2) syscall — or from
-+// tcp_sendmsg_fastopen() for TFO — so the current task is by construction the
-+// process opening the connection. Every socket that can later reach
-+// ACTIVE_ESTABLISHED sent its SYN from there, so a mark recorded at connect is
-+// available at establishment.
++// So the decision is taken where it is already being taken correctly.
++// obi_kprobe_tcp_connect (bpf/generictracer/k_tracer.c) runs at the first
++// instruction of tcp_connect(), reached only through sk_prot->connect from
++// connect(2) or tcp_sendmsg_fastopen(), so the current task is by construction
++// the process dialling. It tests valid_pid() and, only then, records the
++// connection in `sock_pids` keyed by the sorted connection_info_t. Every socket
++// that can reach ACTIVE_ESTABLISHED sent its SYN from there, and the source
++// port is already final (inet_hash_connect() runs before tcp_connect()), so the
++// entry is present and the key is stable by the time we look.
++//
++// The two key derivations agree by construction and OBI already depends on it
++// in the other direction: bpf_sock_ops_parse_hdr_cb() below writes
++// incoming_trace_map with get_connection_info_ops() + sort_connection_info(),
++// and find_trace_for_server_request() (bpf/common/trace_lifecycle.h) reads it
++// with a key built from parse_sock_info(). Both store IPv4 as v4-in-v6 and both
++// hold host-order ports.
 +//
 +// Why prevention rather than eviction: undoing an enrollment means deleting
 +// from a SOCKHASH, and since v6.10 the verifier only lets the program types
@@ -159,67 +140,51 @@ index 078c160..1008e20 100644
 +// fails outright with "cannot pass map_type 18 into func bpf_map_delete_elem".
 +// Not enrolling in the first place is both permitted everywhere and strictly
 +// better: there is no window during which the socket is on tcp_bpf at all.
++//
++// Helper floor: this adds only bpf_map_lookup_elem to the sock_ops program,
++// which has been in bpf_base_func_proto()'s unconditional set since sockmaps
++// existed.
++static __always_inline bool sock_opened_by_instrumented_pid(struct bpf_sock_ops *skops) {
++    connection_info_t conn = get_connection_info_ops(skops);
++    sort_connection_info(&conn);
 +
-+static __always_inline void bpf_sock_ops_connect_cb(struct bpf_sock_ops *skops) {
-+    struct bpf_sock *sk = skops->sk;
-+
-+    if (!sk) {
-+        return;
-+    }
-+
-+    // The discovery filter, read in the only context where it means anything.
-+    // pid_matches() against the `valid_pids` bitmap, memoised in `pid_cache`
-+    // (bpf/pid/pid.h), both filled by rebuildValidPids() in
-+    // pkg/internal/ebpf/generictracer/generictracer.go. With
-+    // OTEL_EBPF_BPF_PID_FILTER_OFF (`filter_pids == 0`) valid_pid() degrades to
-+    // "return the tgid", so everything is marked and enrollment behaves exactly
-+    // as it did upstream.
-+    if (!valid_pid(bpf_get_current_pid_tgid())) {
-+        return;
-+    }
-+
-+    bpf_sk_storage_get(&sk_discovery_ok, sk, &(u8){1}, BPF_SK_STORAGE_GET_F_CREATE);
++    return bpf_map_lookup_elem(&sock_pids, &conn) != NULL;
 +}
 +
  // Helper that writes in the sock map for a sock_ops program
  static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skops) {
-+    struct bpf_sock *sk = skops->sk;
-+
-+    // Default-deny. No mark means the connect callback either did not run for
-+    // this socket or ran for a process discovery excluded, and an unenrolled
-+    // socket keeps its original protocol ops: no sk_msg verdict, no TCP option
-+    // callbacks, nothing for tcp_bpf to stall. The passive path below is
-+    // untouched, so inbound TCP-option parsing for server sockets is unchanged.
-+    if (!sk || !bpf_sk_storage_get(&sk_discovery_ok, sk, NULL, 0)) {
++    // Default-deny. No sock_pids entry means no instrumented task dialled this
++    // connection, and an unenrolled socket keeps its original protocol ops: no
++    // sk_msg verdict, no TCP option callbacks, nothing for tcp_bpf to stall.
++    // The passive path below is untouched, so inbound TCP-option parsing for
++    // server sockets is unchanged.
++    //
++    // Fails closed in every uncertain case. A kernel-internal socket, an MPTCP
++    // subflow dialled from a workqueue, a socket opened before OBI attached or
++    // before its process was discovered: no entry, no enrollment, propagation
++    // lost but nothing corrupted. The residual fail-open is a full 4-tuple
++    // reused by an excluded process while the previous owner's LRU entry is
++    // still live, which lands on today's behaviour for that one socket.
++    if (!sock_opened_by_instrumented_pid(skops)) {
 +        return;
 +    }
 +
      const u64 cookie = bpf_get_socket_cookie(skops);
  
      if (bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY) == 0) {
-@@ -916,8 +992,10 @@ static __always_inline void bpf_sock_ops_parse_hdr_cb(struct bpf_sock_ops *skops
+@@ -916,8 +999,10 @@ static __always_inline void bpf_sock_ops_parse_hdr_cb(struct bpf_sock_ops *skops
      bpf_map_update_elem(&incoming_trace_map, &conn, &tp, BPF_ANY);
  }
  
 -// Tracks all outgoing sockets (BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB)
 -// We don't track incoming, those would be BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB
-+// Tracks outgoing sockets of instrumented processes
-+// (BPF_SOCK_OPS_TCP_CONNECT_CB marks, BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB
-+// enrolls). We don't track incoming, those would be
++// Tracks outgoing sockets of instrumented processes: only connections
++// obi_kprobe_tcp_connect recorded in sock_pids are enrolled
++// (BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB). We don't track incoming, those would be
 +// BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB
  SEC("sockops")
  int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
      struct bpf_sock *sk = skops->sk;
-@@ -927,6 +1005,9 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
-     }
- 
-     switch (skops->op) {
-+    case BPF_SOCK_OPS_TCP_CONNECT_CB:
-+        bpf_sock_ops_connect_cb(skops);
-+        break;
-     case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
-         bpf_sock_ops_active_est_cb(skops);
-         break;
 diff --git a/pkg/internal/ebpf/tpinjector/tpinjector.go b/pkg/internal/ebpf/tpinjector/tpinjector.go
 index 72dfdcd..6b7d48e 100644
 --- a/pkg/internal/ebpf/tpinjector/tpinjector.go

--- a/ebpf/patches/obi/012-discovery-scoped-sockhash.patch
+++ b/ebpf/patches/obi/012-discovery-scoped-sockhash.patch
@@ -1,0 +1,404 @@
+diff --git a/bpf/tpinjector/maps/iter_allowed_socks.h b/bpf/tpinjector/maps/iter_allowed_socks.h
+new file mode 100644
+index 0000000..39144e5
+--- /dev/null
++++ b/bpf/tpinjector/maps/iter_allowed_socks.h
+@@ -0,0 +1,26 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++// Socket inodes the backfill iterator is allowed to enroll, filled by
++// AllowPID() from /proc/<pid>/fd immediately before it runs the iterators and
++// emptied again afterwards.
++//
++// iter/tcp walks a whole network namespace, so on a host-network deployment it
++// sees every socket on the machine and has no way to attribute one to a
++// process — struct sock has no owner. Userspace does: a socket fd's
++// /proc/<pid>/fd link reads back as "socket:[<inode>]", and the same inode is
++// reachable in BPF as sk->sk_socket->file->f_inode->i_ino.
++//
++// Only ever written while the iterator for a single pid is running, so it
++// holds one process's file descriptors at a time.
++struct {
++    __uint(type, BPF_MAP_TYPE_HASH);
++    __uint(max_entries, 8192);
++    __type(key, u64);
++    __type(value, u8);
++} iter_allowed_socks SEC(".maps");
+diff --git a/bpf/tpinjector/maps/sk_discovery_ok.h b/bpf/tpinjector/maps/sk_discovery_ok.h
+new file mode 100644
+index 0000000..b6737fd
+--- /dev/null
++++ b/bpf/tpinjector/maps/sk_discovery_ok.h
+@@ -0,0 +1,26 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++// "The task that opened this socket passed OBI's discovery filter."
++//
++// Written at BPF_SOCK_OPS_TCP_CONNECT_CB, which is the one sock_ops event on
++// an outgoing connection that runs in the connecting task's own context, and
++// read at BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB, which does not. Absence means
++// "not known to be instrumented" and is the deny answer, so a socket whose
++// connect callback never ran (kernel-internal sockets, MPTCP subflows dialled
++// from a workqueue, sockets opened before OBI attached) is left alone.
++//
++// SK_STORAGE rather than a cookie-keyed hash: the fact is socket-lifetime, the
++// kernel frees it on close, and neither writer nor reader has to agree on a
++// key. One byte per outgoing socket in the instrumented cgroup.
++struct {
++    __uint(type, BPF_MAP_TYPE_SK_STORAGE);
++    __uint(map_flags, BPF_F_NO_PREALLOC);
++    __type(key, u32);
++    __type(value, u8);
++} sk_discovery_ok SEC(".maps");
+diff --git a/bpf/tpinjector/sock_iter.c b/bpf/tpinjector/sock_iter.c
+index 5585597..48889d0 100644
+--- a/bpf/tpinjector/sock_iter.c
++++ b/bpf/tpinjector/sock_iter.c
+@@ -14,6 +14,7 @@
+ #include <maps/sock_dir.h>
+ #include <maps/tracked_sock_cookies.h>
+ 
++#include <tpinjector/maps/iter_allowed_socks.h>
+ #include <tpinjector/maps/iter_listening_ports.h>
+ 
+ char __license[] SEC("license") = "Dual MIT/GPL";
+@@ -132,6 +133,26 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
+         return 0;
+     }
+ 
++    // Same default-deny as the sockops enrollment in tpinjector.c: a socket
++    // only joins sock_dir, and so only gets its protocol ops swapped for
++    // tcp_bpf, if it belongs to a process discovery selected.
++    //
++    // iter/tcp cannot decide that on its own. It walks a whole network
++    // namespace — on a host-network deployment, every socket on the machine —
++    // and struct sock records no owning process. It also runs from the OBI
++    // agent's own read() of the iterator fd, so bpf_get_current_pid_tgid() is
++    // the agent. AllowPID() therefore resolves ownership in userspace, from
++    // the discovered pid's /proc/<pid>/fd links, and leaves the inodes here.
++    //
++    // sk_socket is NULL for orphaned sockets (the last fd closed, the kernel
++    // still draining them). Those belong to no process and no longer generate
++    // egress worth propagating on, so failing closed on them is correct.
++    const u64 ino = BPF_CORE_READ((struct sock *)skc, sk_socket, file, f_inode, i_ino);
++
++    if (!ino || !bpf_map_lookup_elem(&iter_allowed_socks, &ino)) {
++        return 0;
++    }
++
+     const u64 cookie = bpf_get_socket_cookie(skc);
+ 
+     char src_buf[k_addr_buf_len] = {};
+diff --git a/bpf/tpinjector/tpinjector.c b/bpf/tpinjector/tpinjector.c
+index 078c160..1008e20 100644
+--- a/bpf/tpinjector/tpinjector.c
++++ b/bpf/tpinjector/tpinjector.c
+@@ -43,6 +43,7 @@
+ 
+ #include <tpinjector/h2_parse.h>
+ #include <tpinjector/inject_policy.h>
++#include <tpinjector/maps/sk_discovery_ok.h>
+ #include <tpinjector/maps/sk_h2_flags.h>
+ #include <tpinjector/maps/sk_h2_conn_flag.h>
+ #include <tpinjector/maps/sk_inject_gate.h>
+@@ -799,8 +800,83 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
+     bpf_sock_ops_cb_flags_set(skops, skops->bpf_sock_ops_cb_flags | flags);
+ }
+ 
++// =============================================================================
++// Discovery-scoped sockhash membership
++// =============================================================================
++//
++// Putting a socket in sock_dir is not free instrumentation. sock_hash_update
++// runs sk_psock_init -> tcp_bpf_update_proto, which replaces the socket's
++// sk_prot with the tcp_bpf one; the tcp_bpf sendmsg/recvmsg paths are what
++// stalled a GitHub runner's log stream and tailscaled's control channel
++// (T-20708). Upstream enrolls unconditionally, so OBI's discovery exclusions
++// mean nothing at the socket layer: every TCP client socket in the cgroup gets
++// converted whether or not its process was selected for instrumentation.
++//
++// The obstacle is that the enrolling callback cannot see the owner.
++// BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB is raised by tcp_finish_connect() ->
++// tcp_init_transfer() (net/ipv4/tcp_input.c) while the SYN-ACK is processed.
++// Unless the socket happened to be owned by the connecting task at that
++// moment, that is NET_RX softirq on whichever CPU took the packet, so
++// bpf_get_current_pid_tgid() returns the interrupted task — an unrelated
++// process, or 0 for the idle task. Testing valid_pid() there would deny
++// instrumented processes at random, which is worse than the bug.
++// BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB is further removed still: it fires for a
++// child socket that no task has returned from accept() yet.
++//
++// BPF_SOCK_OPS_TCP_CONNECT_CB does not have that problem. It is raised from
++// the first line of tcp_connect() (net/ipv4/tcp_output.c), reached only via
++// sk_prot->connect from the connect(2) syscall — or from
++// tcp_sendmsg_fastopen() for TFO — so the current task is by construction the
++// process opening the connection. Every socket that can later reach
++// ACTIVE_ESTABLISHED sent its SYN from there, so a mark recorded at connect is
++// available at establishment.
++//
++// Why prevention rather than eviction: undoing an enrollment means deleting
++// from a SOCKHASH, and since v6.10 the verifier only lets the program types
++// listed in may_update_sockmap() do that — commit 98e948fb60d4 ("bpf: Allow
++// delete from sockmap/sockhash only if update is allowed"), which folded
++// map_delete_elem into the same allow-list after syzkaller found the lock
++// inversion described in ff9105993240. BPF_PROG_TYPE_SK_MSG is not on that
++// list, so obi_packet_extender — the one program that always runs in the
++// sender's task context — cannot evict the socket it was called for; the load
++// fails outright with "cannot pass map_type 18 into func bpf_map_delete_elem".
++// Not enrolling in the first place is both permitted everywhere and strictly
++// better: there is no window during which the socket is on tcp_bpf at all.
++
++static __always_inline void bpf_sock_ops_connect_cb(struct bpf_sock_ops *skops) {
++    struct bpf_sock *sk = skops->sk;
++
++    if (!sk) {
++        return;
++    }
++
++    // The discovery filter, read in the only context where it means anything.
++    // pid_matches() against the `valid_pids` bitmap, memoised in `pid_cache`
++    // (bpf/pid/pid.h), both filled by rebuildValidPids() in
++    // pkg/internal/ebpf/generictracer/generictracer.go. With
++    // OTEL_EBPF_BPF_PID_FILTER_OFF (`filter_pids == 0`) valid_pid() degrades to
++    // "return the tgid", so everything is marked and enrollment behaves exactly
++    // as it did upstream.
++    if (!valid_pid(bpf_get_current_pid_tgid())) {
++        return;
++    }
++
++    bpf_sk_storage_get(&sk_discovery_ok, sk, &(u8){1}, BPF_SK_STORAGE_GET_F_CREATE);
++}
++
+ // Helper that writes in the sock map for a sock_ops program
+ static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skops) {
++    struct bpf_sock *sk = skops->sk;
++
++    // Default-deny. No mark means the connect callback either did not run for
++    // this socket or ran for a process discovery excluded, and an unenrolled
++    // socket keeps its original protocol ops: no sk_msg verdict, no TCP option
++    // callbacks, nothing for tcp_bpf to stall. The passive path below is
++    // untouched, so inbound TCP-option parsing for server sockets is unchanged.
++    if (!sk || !bpf_sk_storage_get(&sk_discovery_ok, sk, NULL, 0)) {
++        return;
++    }
++
+     const u64 cookie = bpf_get_socket_cookie(skops);
+ 
+     if (bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY) == 0) {
+@@ -916,8 +992,10 @@ static __always_inline void bpf_sock_ops_parse_hdr_cb(struct bpf_sock_ops *skops
+     bpf_map_update_elem(&incoming_trace_map, &conn, &tp, BPF_ANY);
+ }
+ 
+-// Tracks all outgoing sockets (BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB)
+-// We don't track incoming, those would be BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB
++// Tracks outgoing sockets of instrumented processes
++// (BPF_SOCK_OPS_TCP_CONNECT_CB marks, BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB
++// enrolls). We don't track incoming, those would be
++// BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB
+ SEC("sockops")
+ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
+     struct bpf_sock *sk = skops->sk;
+@@ -927,6 +1005,9 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
+     }
+ 
+     switch (skops->op) {
++    case BPF_SOCK_OPS_TCP_CONNECT_CB:
++        bpf_sock_ops_connect_cb(skops);
++        break;
+     case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
+         bpf_sock_ops_active_est_cb(skops);
+         break;
+diff --git a/pkg/internal/ebpf/tpinjector/tpinjector.go b/pkg/internal/ebpf/tpinjector/tpinjector.go
+index 72dfdcd..6b7d48e 100644
+--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
++++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
+@@ -12,6 +12,9 @@ import (
+ 	"io"
+ 	"log/slog"
+ 	"os"
++	"path/filepath"
++	"strconv"
++	"strings"
+ 	"sync"
+ 	"syscall"
+ 	"time"
+@@ -50,16 +53,17 @@ type Tracer struct {
+ 	sockhashOK              bool
+ 	iterMu                  sync.Mutex
+ 	itersOnce               sync.Once
+-	seenNetns               *expirable.LRU[uint64, struct{}]
++	seenPIDs                *expirable.LRU[app.PID, struct{}]
++	badNetns                *expirable.LRU[uint64, struct{}]
+ 	netnsAttempts           *expirable.LRU[uint64, int]
+ 	backfillDisabled        bool
+ }
+ 
+ const (
+-	seenNetnsCacheLen = 1024
+-	// the kernel reuses netns inodes and a capacity bound never evicts below the cap, so a new
+-	// container landing on a freed inode would look already backfilled
+-	seenNetnsTTL = 5 * time.Minute
++	backfillCacheLen = 1024
++	// pids and netns inodes are both reused, and a capacity bound never evicts below the cap,
++	// so a new process landing on a freed number would look already backfilled
++	backfillTTL = 5 * time.Minute
+ 	// a namespace that keeps failing is dropped, so one broken container cannot stop the
+ 	// backfill for every other namespace on the host
+ 	maxNetnsAttempts = 3
+@@ -71,17 +75,23 @@ func New(cfg *obi.Config) *Tracer {
+ 		log:           log,
+ 		cfg:           cfg,
+ 		fionreadProbe: sockhashFIONREADProbe,
+-		seenNetns:     expirable.NewLRU[uint64, struct{}](seenNetnsCacheLen, nil, seenNetnsTTL),
+-		netnsAttempts: expirable.NewLRU[uint64, int](seenNetnsCacheLen, nil, seenNetnsTTL),
++		seenPIDs:      expirable.NewLRU[app.PID, struct{}](backfillCacheLen, nil, backfillTTL),
++		badNetns:      expirable.NewLRU[uint64, struct{}](backfillCacheLen, nil, backfillTTL),
++		netnsAttempts: expirable.NewLRU[uint64, int](backfillCacheLen, nil, backfillTTL),
+ 	}
+ }
+ 
+-// AllowPID backfills sock_dir with pre-existing sockets: iter/tcp only walks the opener's netns
++// AllowPID backfills sock_dir with this process's pre-existing sockets.
++//
++// The walk is per pid rather than per netns because it is now scoped: iter/tcp
++// sees every socket in the namespace and cannot attribute one to a process, so
++// the discovered pid's own socket inodes are published to iter_allowed_socks
++// first and retracted afterwards. See bpf/tpinjector/maps/iter_allowed_socks.h.
+ func (p *Tracer) AllowPID(pid app.PID, _ uint32, _ *exec.FileInfo) {
+ 	p.iterMu.Lock()
+ 	defer p.iterMu.Unlock()
+ 
+-	if p.backfillDisabled {
++	if p.backfillDisabled || p.seenPIDs.Contains(pid) {
+ 		return
+ 	}
+ 
+@@ -92,11 +102,26 @@ func (p *Tracer) AllowPID(pid app.PID, _ uint32, _ *exec.FileInfo) {
+ 	}
+ 
+ 	inode := info.Sys().(*syscall.Stat_t).Ino
+-	if p.seenNetns.Contains(inode) {
++	if p.badNetns.Contains(inode) {
+ 		return
+ 	}
+ 
+-	for _, it := range p.Iters() {
++	iters := p.Iters()
++	if len(iters) == 0 {
++		return
++	}
++
++	scope := p.publishBackfillScope(pid)
++	defer p.retractBackfillScope(scope)
++
++	// No sockets of its own to enroll; the namespace's other sockets are
++	// deliberately not ours to convert.
++	if len(scope) == 0 {
++		p.seenPIDs.Add(pid, struct{}{})
++		return
++	}
++
++	for _, it := range iters {
+ 		if err := netns.WithNetNS(int(pid), func() error {
+ 			return it.Run(p.log)
+ 		}); err != nil {
+@@ -120,7 +145,7 @@ func (p *Tracer) AllowPID(pid app.PID, _ uint32, _ *exec.FileInfo) {
+ 			if attempts >= maxNetnsAttempts {
+ 				p.log.Warn("giving up on socket backfill for this network namespace",
+ 					"ino", inode, "attempts", attempts)
+-				p.seenNetns.Add(inode, struct{}{})
++				p.badNetns.Add(inode, struct{}{})
+ 			}
+ 			return
+ 		}
+@@ -128,7 +153,77 @@ func (p *Tracer) AllowPID(pid app.PID, _ uint32, _ *exec.FileInfo) {
+ 
+ 	// reached only when every iterator ran; a failure above returns so a later pid retries
+ 	p.netnsAttempts.Remove(inode)
+-	p.seenNetns.Add(inode, struct{}{})
++	p.seenPIDs.Add(pid, struct{}{})
++}
++
++// publishBackfillScope names the sockets obi_sk_iter_tcp may enroll during this
++// process's backfill, and returns them so the caller can retract them again.
++//
++// A socket file descriptor's /proc/<pid>/fd link reads back as
++// "socket:[<inode>]", and the same inode is reachable from a struct sock in
++// BPF, which is the only join between "this process owns it" and "the iterator
++// is looking at it" available without walking /proc/net tables.
++func (p *Tracer) publishBackfillScope(pid app.PID) []uint64 {
++	scope := p.bpfIterObjects.IterAllowedSocks
++	if scope == nil {
++		return nil
++	}
++
++	dir := fmt.Sprintf("/proc/%d/fd", pid)
++	entries, err := os.ReadDir(dir)
++	if err != nil {
++		p.log.Debug("cannot list process file descriptors", "pid", pid, "error", err)
++		return nil
++	}
++
++	var inodes []uint64
++	for _, entry := range entries {
++		// descriptors close under us constantly; an unreadable one is not an error
++		target, err := os.Readlink(filepath.Join(dir, entry.Name()))
++		if err != nil {
++			continue
++		}
++		ino, ok := socketInode(target)
++		if !ok {
++			continue
++		}
++		if err := scope.Put(ino, uint8(1)); err != nil {
++			p.log.Debug("cannot record backfill scope", "pid", pid, "ino", ino, "error", err)
++			continue
++		}
++		inodes = append(inodes, ino)
++	}
++
++	return inodes
++}
++
++func (p *Tracer) retractBackfillScope(inodes []uint64) {
++	scope := p.bpfIterObjects.IterAllowedSocks
++	if scope == nil {
++		return
++	}
++
++	for _, ino := range inodes {
++		if err := scope.Delete(ino); err != nil {
++			p.log.Debug("cannot clear backfill scope", "ino", ino, "error", err)
++		}
++	}
++}
++
++// socketInode reads the inode out of a "socket:[12345]" /proc/<pid>/fd link.
++func socketInode(target string) (uint64, bool) {
++	const prefix, suffix = "socket:[", "]"
++
++	if !strings.HasPrefix(target, prefix) || !strings.HasSuffix(target, suffix) {
++		return 0, false
++	}
++
++	ino, err := strconv.ParseUint(target[len(prefix):len(target)-len(suffix)], 10, 64)
++	if err != nil {
++		return 0, false
++	}
++
++	return ino, true
+ }
+ 
+ func (p *Tracer) BlockPID(app.PID, uint32) {}

--- a/ebpf/patches/obi/013-deny-before-parent-fallback.patch
+++ b/ebpf/patches/obi/013-deny-before-parent-fallback.patch
@@ -1,0 +1,569 @@
+diff --git a/bpf/pid/maps/denied_pids.h b/bpf/pid/maps/denied_pids.h
+new file mode 100644
+index 000000000..fb49317f9
+--- /dev/null
++++ b/bpf/pid/maps/denied_pids.h
+@@ -0,0 +1,37 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++#include <common/pin_internal.h>
++
++#include <pid/maps/map_sizing.h>
++
++#include <pid/types/pid_data.h>
++
++// Processes discovery excluded, keyed exactly like the allow-list that
++// pid_matches() reads: the pid as seen inside its own pid namespace, plus that
++// namespace's inode. Filled from userspace by the criteria matcher, which is
++// the only component that evaluates exclude_instrument and the only one that
++// sees the processes it drops.
++//
++// An exact-match hash rather than a second copy of the `valid_pids` bitmap on
++// purpose. That bitmap hashes (ns, pid) into 192053 bits with no collision
++// resolution, which upstream can afford because a collision there fails *open*:
++// some extra process passes the filter. The same collision in a deny structure
++// would fail closed and silently stop instrumenting a process the user did
++// select, so this side has to be exact.
++//
++// Sized like `valid_pids` (1000 processes * 3 namespace levels). A full map
++// means new denials are refused, which userspace reports; it does not evict, so
++// an existing denial can never quietly lapse.
++struct {
++    __uint(type, BPF_MAP_TYPE_HASH);
++    __uint(max_entries, k_max_concurrent_pids);
++    __type(key, pid_data_t);
++    __type(value, u8);
++    __uint(pinning, OBI_PIN_INTERNAL);
++} denied_pids SEC(".maps");
+diff --git a/bpf/pid/pid.h b/bpf/pid/pid.h
+index 7cea1b777..88866c03f 100644
+--- a/bpf/pid/pid.h
++++ b/bpf/pid/pid.h
+@@ -8,6 +8,7 @@
+ 
+ #include <logger/bpf_dbg.h>
+ 
++#include <pid/maps/denied_pids.h>
+ #include <pid/maps/pid_cache.h>
+ #include <pid/maps/valid_pids.h>
+ 
+@@ -66,6 +67,32 @@ static __always_inline u32 valid_pid(u64 id) {
+     if (a_pid != 0) {
+         pid_data_t p_key = {.pid = a_pid, .ns = pid_ns_id};
+ 
++        // Discovery exclusions, honoured before the allow-list and before the
++        // parent fallback below.
++        //
++        // The fallback is deliberate — it is how OBI follows an instrumented
++        // process into its children — but it also let an *excluded* process
++        // pass on its parent's ticket. That is not hypothetical: with
++        // `open_ports` discovery, pid 1 is routinely instrumented, and every
++        // process on the machine descends from pid 1, so `exclude_instrument`
++        // meant nothing in the kernel. It was measured on a real host, where
++        // an excluded tailscaled enrolled into the sockhash 2/2 times.
++        //
++        // Only the process's own identity is consulted. A denied parent does
++        // not taint its children: a supervisor the user excluded may well fork
++        // the workload they asked for, and that workload has its own entry in
++        // the allow-list. So this rejects exactly what userspace rejected, and
++        // the fork-following below is otherwise untouched.
++        //
++        // Placed after the pid_cache lookup, not before it, because the cache
++        // is a positive memo and the publisher evicts the pids it denies (see
++        // pkg/ebpf/common/denied_pids.go). Checking here leaves the hot path
++        // for allowed processes exactly as it was: one cache lookup, no task
++        // walk, no second map.
++        if (bpf_map_lookup_elem(&denied_pids, &p_key)) {
++            return 0;
++        }
++
+         const u8 found_ns_pid = pid_matches(&p_key);
+ 
+         if (found_ns_pid) {
+diff --git a/pkg/appolly/discover/finder.go b/pkg/appolly/discover/finder.go
+index 29ca47b98..5d3159678 100644
+--- a/pkg/appolly/discover/finder.go
++++ b/pkg/appolly/discover/finder.go
+@@ -127,7 +127,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
+ 	), swarm.WithID("LanguageDecoratorProvider"))
+ 
+ 	criteriaFilteredEvents := msgh.QueueFromConfig[[]Event[ProcessMatch]](pf.cfg, "criteriaFilteredEvents")
+-	swi.Add(criteriaMatcherProvider(pf.cfg, langEnrichedEvents, criteriaFilteredEvents, configCriteria, startConfig.dynamicPIDSelector),
++	swi.Add(criteriaMatcherProvider(pf.cfg, langEnrichedEvents, criteriaFilteredEvents, configCriteria, startConfig.dynamicPIDSelector, pf.ebpfEventContext),
+ 		swarm.WithID("CriteriaMatcher"))
+ 	swi.Add(dynamicMatcherProvider(langEnrichedEvents, criteriaFilteredEvents, appDynamicSelector),
+ 		swarm.WithID("DynamicMatcher"))
+diff --git a/pkg/appolly/discover/matcher.go b/pkg/appolly/discover/matcher.go
+index cafef1741..2ffec501d 100644
+--- a/pkg/appolly/discover/matcher.go
++++ b/pkg/appolly/discover/matcher.go
+@@ -38,6 +38,7 @@ func criteriaMatcherProvider(
+ 	output *msg.Queue[[]Event[ProcessMatch]],
+ 	configCriteria []services.Selector,
+ 	dynamicSelector *DynamicPIDSelector,
++	eventContext *ebpfcommon.EBPFEventContext,
+ ) swarm.InstanceFunc {
+ 	instrumenterNamespace, _ := namespaceFetcherFunc(app.PID(osPidFunc()))
+ 	if dynamicSelector != nil {
+@@ -45,8 +46,9 @@ func criteriaMatcherProvider(
+ 		return swarm.DirectInstance(emptyFunc)
+ 	}
+ 
++	log := slog.With("component", "discover.CriteriaMatcher")
+ 	m := &Matcher{
+-		Log:                 slog.With("component", "discover.CriteriaMatcher"),
++		Log:                 log,
+ 		Criteria:            configCriteria,
+ 		ExcludeCriteria:     ExcludingCriteria(cfg),
+ 		LogEnricherCriteria: LogEnricherFindingCriteria(cfg),
+@@ -55,6 +57,7 @@ func criteriaMatcherProvider(
+ 		Output:              output,
+ 		Namespace:           instrumenterNamespace,
+ 		HasHostPidAccess:    hasHostPidAccess(),
++		Denied:              ebpfcommon.NewDeniedPIDs(eventContext, log),
+ 	}
+ 	return swarm.DirectInstance(m.Run)
+ }
+@@ -74,6 +77,9 @@ type Matcher struct {
+ 	Output           *msg.Queue[[]Event[ProcessMatch]]
+ 	Namespace        string
+ 	HasHostPidAccess bool
++	// Denied mirrors the exclusion decisions taken here into the BPF pid
++	// filter, which cannot derive them: see ebpfcommon.DeniedPIDs.
++	Denied *ebpfcommon.DeniedPIDs
+ }
+ 
+ // ProcessMatch matches a found process with the first selection criteria it fulfilled.
+@@ -105,6 +111,10 @@ func (m *Matcher) Run(ctx context.Context) {
+ }
+ 
+ func (m *Matcher) filter(events []Event[ProcessAttrs]) []Event[ProcessMatch] {
++	// Exclusions recorded before the BPF pid filter was loaded still have to
++	// reach it; a no-op once they have.
++	m.Denied.Flush()
++
+ 	var matches []Event[ProcessMatch]
+ 	for _, ev := range events {
+ 		if ev.Type == EventDeleted {
+@@ -173,6 +183,23 @@ func (m *Matcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], bool) {
+ 		return Event[ProcessMatch]{}, false
+ 	}
+ 
++	// Publish the exclusion decision to the BPF pid filter, which cannot take
++	// it: this is the only component that evaluates exclude_instrument, and
++	// excluded processes are dropped here rather than forwarded, so nothing
++	// downstream ever hears about them. Without this, valid_pid()'s parent
++	// fallback keeps letting an excluded process through on an instrumented
++	// ancestor's ticket. The retraction is for pid reuse: this pid may be the
++	// same number a denied process used to have.
++	//
++	// Nothing else about the matching below changes, exclusion included: the
++	// checks in matchCriteria() and on the parent-history route are upstream's
++	// and stay authoritative for this pipeline.
++	if m.isExcluded(&obj, proc) {
++		m.Denied.Deny(obj.pid)
++	} else {
++		m.Denied.Forget(obj.pid)
++	}
++
+ 	if processMatch := m.matchCriteria(obj, proc); processMatch != nil {
+ 		m.ProcessHistory[obj.pid] = *processMatch
+ 
+@@ -200,6 +227,9 @@ func (m *Matcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], bool) {
+ }
+ 
+ func (m *Matcher) filterDeleted(obj ProcessAttrs) (Event[ProcessMatch], bool) {
++	// Denials outlive nothing: the pid is free for reuse the moment it is gone.
++	m.Denied.Forget(obj.pid)
++
+ 	procMatch, ok := m.ProcessHistory[obj.pid]
+ 	if !ok {
+ 		m.Log.Debug("deleted untracked process. Ignoring", "pid", obj.pid)
+diff --git a/pkg/appolly/discover/matcher_test.go b/pkg/appolly/discover/matcher_test.go
+index c4b28eb99..dce07a516 100644
+--- a/pkg/appolly/discover/matcher_test.go
++++ b/pkg/appolly/discover/matcher_test.go
+@@ -50,7 +50,7 @@ func TestMatchersMutuallyExclusive(t *testing.T) {
+ 		}
+ 
+ 		swi := swarm.Instancer{}
+-		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, sel), swarm.WithID("CriteriaMatcher"))
++		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, sel, nil), swarm.WithID("CriteriaMatcher"))
+ 		swi.Add(dynamicMatcherProvider(inQ, outQ, sel.appSignals()), swarm.WithID("DynamicMatcher"))
+ 		runner, err := swi.Instance(t.Context())
+ 		require.NoError(t, err)
+@@ -81,7 +81,7 @@ func TestMatchersMutuallyExclusive(t *testing.T) {
+ 		}
+ 
+ 		swi := swarm.Instancer{}
+-		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, nil), swarm.WithID("CriteriaMatcher"))
++		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, nil, nil), swarm.WithID("CriteriaMatcher"))
+ 		swi.Add(dynamicMatcherProvider(inQ, outQ, nil), swarm.WithID("DynamicMatcher"))
+ 		runner, err := swi.Instance(t.Context())
+ 		require.NoError(t, err)
+@@ -131,7 +131,7 @@ func TestCriteriaMatcher(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -182,7 +182,7 @@ func TestCriteriaMatcherLanguage(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -232,7 +232,7 @@ func TestCriteriaMatcher_Exclude(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -273,7 +273,7 @@ func TestCriteriaMatcher_Exclude_Metadata(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -320,7 +320,7 @@ func TestCriteriaMatcher_MetadataWithDeprecatedPathRegexp(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, criteria, nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, criteria, nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer func() {
+@@ -364,7 +364,7 @@ func TestCriteriaMatcher_MustMatchAllAttributes(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -419,7 +419,7 @@ func TestCriteriaMatcherMissingPort(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -461,7 +461,7 @@ func TestCriteriaMatcherExcludedChildDoesNotInheritParentMatch(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -563,7 +563,7 @@ func TestCriteriaMatcherContainersOnly(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -702,7 +702,7 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
+ 			discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 			filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 			filteredProcesses := filteredProcessesQu.Subscribe()
+-			matcherFunc, err := criteriaMatcherProvider(&tc.cfg, discoveredProcesses, filteredProcessesQu, FindingCriteria(&tc.cfg), nil)(t.Context())
++			matcherFunc, err := criteriaMatcherProvider(&tc.cfg, discoveredProcesses, filteredProcessesQu, FindingCriteria(&tc.cfg), nil, nil)(t.Context())
+ 			require.NoError(t, err)
+ 			go matcherFunc(t.Context())
+ 			defer filteredProcessesQu.Close()
+@@ -737,7 +737,7 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
+ 		discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 		filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 		filteredProcesses := filteredProcessesQu.Subscribe()
+-		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 		require.NoError(t, err)
+ 		go matcherFunc(t.Context())
+ 		defer filteredProcessesQu.Close()
+@@ -768,7 +768,7 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
+ 		discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 		filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 		filteredProcesses := filteredProcessesQu.Subscribe()
+-		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 		require.NoError(t, err)
+ 		go matcherFunc(t.Context())
+ 		defer filteredProcessesQu.Close()
+@@ -957,7 +957,7 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
+ 
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+ 
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 
+ 	require.NoError(t, err)
+ 
+diff --git a/pkg/appolly/discover/watcher_kube_test.go b/pkg/appolly/discover/watcher_kube_test.go
+index 62304ba4e..38bbab209 100644
+--- a/pkg/appolly/discover/watcher_kube_test.go
++++ b/pkg/appolly/discover/watcher_kube_test.go
+@@ -205,7 +205,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
+       version: "v[0-9]*"
+ `), &pipeConfig))
+ 
+-	swi.Add(criteriaMatcherProvider(&pipeConfig, connectQueue, outputQueue, FindingCriteria(&pipeConfig), nil))
++	swi.Add(criteriaMatcherProvider(&pipeConfig, connectQueue, outputQueue, FindingCriteria(&pipeConfig), nil, nil))
+ 
+ 	nodesRunner, err := swi.Instance(t.Context())
+ 	require.NoError(t, err)
+diff --git a/pkg/ebpf/common/denied_pids.go b/pkg/ebpf/common/denied_pids.go
+new file mode 100644
+index 000000000..03e25c633
+--- /dev/null
++++ b/pkg/ebpf/common/denied_pids.go
+@@ -0,0 +1,224 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common"
++
++import (
++	"errors"
++	"log/slog"
++	"sync"
++
++	"github.com/cilium/ebpf"
++
++	"go.opentelemetry.io/obi/pkg/appolly/app"
++	"go.opentelemetry.io/obi/pkg/internal/procs"
++)
++
++// Both maps are declared in bpf/pid/maps/ with OBI_PIN_INTERNAL, so
++// ResolveMaps() creates exactly one of each per agent and hands the same
++// object to every collection that includes pid.h. Reaching them by name
++// through EBPFEventContext.EBPFMaps is therefore reaching the maps the kernel
++// side actually reads, and it does not depend on which tracer happens to be
++// loaded: the entry outlives any single ProcessTracer.
++const (
++	deniedPIDsMapName = "denied_pids"
++	pidCacheMapName   = "pid_cache"
++)
++
++// deniedPIDKey mirrors pid_data_t (bpf/pid/types/pid_data.h).
++type deniedPIDKey struct {
++	Pid uint32
++	Ns  uint32
++}
++
++// DeniedPIDs publishes discovery's exclusions to the BPF pid filter.
++//
++// valid_pid() (bpf/pid/pid.h) falls back to the parent's pid when a process is
++// not in the allow-list, which is how OBI follows an instrumented process into
++// its children. Nothing told the kernel about the processes discovery had
++// *excluded*, so an excluded process under an instrumented parent — and with
++// `open_ports` discovery, pid 1 is often instrumented — passed the filter
++// anyway. This is the missing half: the criteria matcher records what it
++// excluded here, and valid_pid() rejects those identities before it consults
++// either the allow-list or the parent.
++//
++// Keys are per namespaced pid, exactly as PIDsFilter.addPID() records the
++// allow side: /proc/<pid>/status NSpid lists the process's pid at every level,
++// and BPF only ever derives the innermost one, so publishing all of them makes
++// the two sides agree without having to guess which level the kernel will see.
++type DeniedPIDs struct {
++	mu  sync.Mutex
++	ctx *EBPFEventContext
++	log *slog.Logger
++	// keys published per host pid, kept because the process is gone from /proc
++	// by the time it has to be retracted
++	published map[app.PID][]deniedPIDKey
++	// set when an entry in published is not in the BPF map. The maps do not
++	// exist until the first tracer loads, and the first discovery poll
++	// normally runs before that.
++	backlog bool
++}
++
++// NewDeniedPIDs returns a publisher writing into eventContext's shared maps.
++// A nil eventContext yields a publisher that records nothing, which is what
++// unit tests and the darwin build get.
++func NewDeniedPIDs(eventContext *EBPFEventContext, log *slog.Logger) *DeniedPIDs {
++	return &DeniedPIDs{
++		ctx:       eventContext,
++		log:       log,
++		published: map[app.PID][]deniedPIDKey{},
++	}
++}
++
++// Deny records pid as excluded from instrumentation.
++func (d *DeniedPIDs) Deny(pid app.PID) {
++	if d == nil || d.ctx == nil {
++		return
++	}
++
++	d.mu.Lock()
++	defer d.mu.Unlock()
++
++	if _, known := d.published[pid]; !known {
++		keys := d.keysFor(pid)
++		if len(keys) == 0 {
++			return
++		}
++		d.log.Debug("excluding pid from the BPF pid filter", "pid", pid, "nspids", len(keys))
++		d.published[pid] = keys
++		d.backlog = true
++	}
++
++	if d.backlog {
++		// one failed publish retries every recorded pid, so a denial recorded
++		// before the maps existed cannot be lost
++		d.flushLocked()
++	}
++}
++
++// Forget retracts pid's denial: it exited, or it turned out to match the
++// discovery criteria after all. Pids are reused, and a denial that outlived
++// its process would silently stop instrumenting the next owner.
++func (d *DeniedPIDs) Forget(pid app.PID) {
++	if d == nil || d.ctx == nil {
++		return
++	}
++
++	d.mu.Lock()
++	defer d.mu.Unlock()
++
++	keys, known := d.published[pid]
++	if !known {
++		return
++	}
++	delete(d.published, pid)
++
++	denied, _ := d.maps()
++	if denied == nil {
++		return
++	}
++	for _, key := range keys {
++		// a pid namespace teardown can take the whole key set with it
++		if err := denied.Delete(key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
++			d.log.Debug("cannot retract excluded pid", "pid", pid, "error", err)
++		}
++	}
++}
++
++// Flush retries denials recorded while the BPF maps were still unavailable.
++// Cheap and a no-op in the common case; the matcher calls it once per batch of
++// process events.
++func (d *DeniedPIDs) Flush() {
++	if d == nil || d.ctx == nil {
++		return
++	}
++
++	d.mu.Lock()
++	defer d.mu.Unlock()
++
++	if d.backlog {
++		d.flushLocked()
++	}
++}
++
++func (d *DeniedPIDs) flushLocked() {
++	denied, cache := d.maps()
++	if denied == nil {
++		d.log.Debug("BPF pid filter not loaded yet, deferring exclusions", "pids", len(d.published))
++		return
++	}
++
++	d.backlog = false
++	for pid, keys := range d.published {
++		for _, key := range keys {
++			if err := denied.Put(key, uint8(1)); err != nil {
++				// A full map is the interesting case: it means new exclusions
++				// stop reaching the kernel, which fails open.
++				d.log.Warn("cannot publish excluded pid to the BPF pid filter",
++					"pid", pid, "nspid", key.Pid, "ns", key.Ns, "error", err)
++				d.backlog = true
++				continue
++			}
++			evictPIDCache(cache, key.Pid)
++		}
++		evictPIDCache(cache, uint32(pid))
++	}
++}
++
++// evictPIDCache drops a memoised valid_pid() pass.
++//
++// pid_cache is a positive cache: valid_pid() writes it only for a pid it just
++// accepted, and returns from it without looking at anything else. An excluded
++// process that made egress before discovery got to it was accepted on its
++// parent's ticket and cached, so publishing the denial without this would
++// change nothing for that process for as long as the entry lives.
++//
++// The map is keyed by a bare u32 with no namespace, and upstream looks it up
++// with the host tgid while storing under the namespaced pid, so both spellings
++// are evicted. A number that collides with an unrelated host pid costs that
++// process one re-evaluation of valid_pid(), which is what BlockPID() has
++// always done too.
++func evictPIDCache(cache *ebpf.Map, pid uint32) {
++	if cache == nil {
++		return
++	}
++	_ = cache.Delete(pid)
++}
++
++// keysFor reads the identities BPF will see for a host pid. Mirrors
++// PIDsFilter.addPID(): the pid namespace inode plus every level of NSpid.
++func (d *DeniedPIDs) keysFor(pid app.PID) []deniedPIDKey {
++	ns, err := procs.FindNamespace(pid)
++	if err != nil {
++		// the process exited between the poll and here; the next poll reports
++		// it deleted and there is nothing left to deny
++		d.log.Debug("cannot read pid namespace of excluded process", "pid", pid, "error", err)
++		return nil
++	}
++
++	nsPIDs, err := procs.FindNamespacedPids(pid)
++	if err != nil {
++		d.log.Debug("cannot read namespaced pids of excluded process", "pid", pid, "error", err)
++		return nil
++	}
++	if len(nsPIDs) == 0 {
++		// no NSpid line in /proc/<pid>/status: not a namespaced kernel, so the
++		// pid BPF derives is this one. The allow side skips such a process
++		// entirely; denying is the safe direction, so it is published instead.
++		nsPIDs = []app.PID{pid}
++	}
++
++	keys := make([]deniedPIDKey, 0, len(nsPIDs))
++	for _, nsPID := range nsPIDs {
++		keys = append(keys, deniedPIDKey{Pid: uint32(nsPID), Ns: ns})
++	}
++
++	return keys
++}
++
++func (d *DeniedPIDs) maps() (denied, cache *ebpf.Map) {
++	d.ctx.MapsLock.Lock()
++	defer d.ctx.MapsLock.Unlock()
++
++	return d.ctx.EBPFMaps[deniedPIDsMapName], d.ctx.EBPFMaps[pidCacheMapName]
++}

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -15,3 +15,22 @@ Currently contains patches:
   connections the fill deliberately bails, so the detector would otherwise judge
   stale bytes from a previous message and could splice a Traceparent header into
   TLS ciphertext, corrupting the stream (peer-side bad_record_mac).
+* 010-default-deny-injection-gate.patch
+  Invert tpinjector's HTTP/1 trust model. Upstream mutates any egress message
+  whose first bytes look like a request method, which is why binary streams get
+  corrupted; this makes injection opt-in instead. A new per-socket
+  `sk_inject_gate` SK_STORAGE byte parks sockets permanently, checked at the top
+  of `obi_packet_extender` before the existing-trace route can schedule a TCP
+  option. On unparked sockets HTTP/1 injection now requires a complete request
+  line — method, target, `HTTP/1.<digit>`, CRLF — in the freshly filled scratch
+  buffer, and a request carrying an `Upgrade:` header parks the socket without
+  being injected into. That last part is the client-side half of 008: the
+  server's 101 arrives on ingress, which an egress-only sk_msg program never
+  sees, so `tailscaled`'s control channel (Noise) and DERP client (binary
+  frames) were unprotected. The confirmed-HTTP/2 chain is untouched, it is
+  already default-deny.
+* 011-valid-pid-first.patch
+  Check OBI's discovery filter (`valid_pid`) at the top of
+  `obi_packet_extender`. Upstream checks it only on the fall-through route, so
+  the existing-trace and Go-gRPC coordination routes could mutate messages of
+  processes that were never selected for instrumentation.

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -29,6 +29,19 @@ Currently contains patches:
   sees, so `tailscaled`'s control channel (Noise) and DERP client (binary
   frames) were unprotected. The confirmed-HTTP/2 chain is untouched, it is
   already default-deny.
+
+  The gate's two bounded scans and the dispatch that follows them are three
+  separate sk_msg programs (`k_tail_http1_request_line`,
+  `k_tail_http1_upgrade`, `k_tail_http1_dispatch`). That is not decoration: the
+  verifier keeps the exact loop offset each scan ends on, so a scan inlined
+  ahead of other code re-verifies all of it once per possible offset. Inlined,
+  `obi_packet_extender` hit the 1M complexity limit and the whole verdict
+  program failed to load — which disables the injector silently rather than
+  restricting it. A tail call ends the program, so each scan's fan-out reaches
+  only the few instructions after it. For the same reason the request line is
+  matched backwards from the message's first CRLF instead of forwards from the
+  method token, whose seven possible lengths would enter the loop as seven
+  states.
 * 011-valid-pid-first.patch
   Check OBI's discovery filter (`valid_pid`) at the top of
   `obi_packet_extender`. Upstream checks it only on the fall-through route, so

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -58,24 +58,42 @@ Currently contains patches:
   opened it passed `valid_pid`.
 
   Why the enrolling callback could not just test `valid_pid` itself: it does
-  not run in the owner's context. `BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB` is
-  raised by `tcp_finish_connect` -> `tcp_init_transfer`
-  (net/ipv4/tcp_input.c:6113), i.e. while the SYN-ACK is processed — normally
-  NET_RX softirq on whichever CPU took the packet, so
-  `bpf_get_current_pid_tgid()` there is the interrupted task, or 0 for the idle
-  task. Testing discovery there would deny instrumented processes at random.
-  `BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB` is further removed still: it fires for
-  a child socket no task has returned from `accept()` yet.
+  not run in the owner's context, and on the supported kernel floor it cannot
+  even ask. `BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB` is raised by
+  `tcp_finish_connect` -> `tcp_init_transfer` (net/ipv4/tcp_input.c:6113), i.e.
+  while the SYN-ACK is processed — normally NET_RX softirq on whichever CPU
+  took the packet, so the current task is the interrupted one, or 0 for the
+  idle task. Deciding discovery there would deny instrumented processes at
+  random. `BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB` is further removed still: it
+  fires for a child socket no task has returned from `accept()` yet. And
+  `bpf_get_current_pid_tgid()` reaches `BPF_PROG_TYPE_SOCK_OPS` only through
+  `bpf_base_func_proto()`, which did not offer it until v6.10 (Yonghong Song,
+  "bpf: Allow bpf_get_[ns_]current_pid_tgid() in all program types"); an
+  earlier draft of this patch used it and CI caught the consequence on
+  ubuntu-22.04 — `unknown func bpf_get_current_pid_tgid#14`, injector not
+  loaded.
 
-  The decision therefore moves to `BPF_SOCK_OPS_TCP_CONNECT_CB`, raised from
-  the first line of `tcp_connect()` (net/ipv4/tcp_output.c:3952), which is
-  reached only through `sk_prot->connect` from `connect(2)` — or
-  `tcp_sendmsg_fastopen()` for TFO — so the current task is by construction the
-  process dialling. It records a byte in a new `sk_discovery_ok` SK_STORAGE,
-  and the established callback enrolls only marked sockets. No new attachment:
-  the sockops program was already there, this is one more `case`. The passive
-  path is untouched, so inbound TCP-option parsing on server sockets behaves
-  exactly as before.
+  So the decision is read from where OBI already takes it correctly.
+  `obi_kprobe_tcp_connect` (bpf/generictracer/k_tracer.c) runs at the first
+  instruction of `tcp_connect()`, reached only through `sk_prot->connect` from
+  `connect(2)` — or `tcp_sendmsg_fastopen()` for TFO — so the current task is by
+  construction the process dialling. It already tests `valid_pid()` and, only
+  then, records the connection in the `sock_pids` LRU keyed by the sorted
+  `connection_info_t`. `bpf_sock_ops_active_est_cb` now looks that key up and
+  enrolls only on a hit. The source port is final before `tcp_connect()` runs
+  (`inet_hash_connect()` precedes it), so the entry exists and the key is
+  stable by the time the established callback fires. The two key derivations
+  agree by construction and OBI already relies on that in the other direction:
+  `bpf_sock_ops_parse_hdr_cb` writes `incoming_trace_map` with
+  `get_connection_info_ops()` + `sort_connection_info()`, and
+  `find_trace_for_server_request()` reads it with a key built from
+  `parse_sock_info()`.
+
+  Nothing is attached that was not attached before, no new BPF program, no new
+  map on the sockops side, and the only helper this adds to any program is
+  `bpf_map_lookup_elem`, which has been in the unconditional part of
+  `bpf_base_func_proto()` since sockmaps existed. The passive path is untouched,
+  so inbound TCP-option parsing on server sockets behaves exactly as before.
 
   Prevention rather than eviction, because eviction is not available. Removing
   a socket from a sockhash means `bpf_map_delete_elem`, and since v6.10 the
@@ -86,24 +104,28 @@ Currently contains patches:
   not on that list, so `obi_packet_extender` — the one program that always runs
   in the sender's task context — cannot evict the socket it was called for; the
   program fails to load outright with `cannot pass map_type 18 into func
-  bpf_map_delete_elem`, which would silently disable the injector. Not
+  bpf_map_delete_elem`, which would silently disable the injector. (That was
+  measured, not assumed: the eviction design was built and run first.) Not
   enrolling is also strictly better than evicting: there is no window at all,
   rather than "off the tcp_bpf path after the first egress message".
 
   Exposure window: none for sockets opened while OBI is attached. A socket
-  whose `connect()` predates OBI, or predates the discovery of its process,
-  carries no mark and is simply never enrolled — losing propagation, never
-  corrupting. The `AllowPID` backfill is what recovers those, and it is scoped
-  the same way: `iter/tcp` walks an entire network namespace and `struct sock`
-  records no owner, so `AllowPID` now publishes the discovered pid's own socket
-  inodes — read from its `/proc/<pid>/fd` links, matched in BPF against
+  whose `connect()` predates OBI, or predates the discovery of its process, has
+  no `sock_pids` entry and is simply never enrolled — losing propagation, never
+  corrupting. The residual fail-open is an excluded process reusing a full
+  4-tuple while the previous owner's LRU entry is still live, which lands on
+  today's behaviour for that one socket. The `AllowPID` backfill is what
+  recovers pre-existing connections, and it is scoped the same way: `iter/tcp`
+  walks an entire network namespace and `struct sock` records no owner, so
+  `AllowPID` now publishes the discovered pid's own socket inodes — read from
+  its `/proc/<pid>/fd` links, matched in BPF against
   `sk->sk_socket->file->f_inode->i_ino` — into `iter_allowed_socks` for the
   duration of the walk. That also makes the walk per-pid rather than per-netns,
   since the allow-set is per-pid.
 
   Verifier cost: the whole sk_msg chain is byte-identical to 011
   (`obi_packet_extender` stays at 851 instructions, every tail-called program
-  unchanged); `obi_sockmap_tracker` goes 1801 -> 2195 and `obi_sk_iter_tcp`
+  unchanged); `obi_sockmap_tracker` goes 1801 -> 1881 and `obi_sk_iter_tcp`
   428 -> 468.
 
   `ebpf/tests/egress-integrity` grows a `sockhash-scoping` scenario that proves

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -47,3 +47,71 @@ Currently contains patches:
   `obi_packet_extender`. Upstream checks it only on the fall-through route, so
   the existing-trace and Go-gRPC coordination routes could mutate messages of
   processes that were never selected for instrumentation.
+* 012-discovery-scoped-sockhash.patch
+  Make discovery exclusions real at the socket layer. Upstream puts *every*
+  outgoing TCP socket in the instrumented cgroup into the `sock_dir` sockhash,
+  which is not passive observation: `sock_hash_update` runs `sk_psock_init` ->
+  `tcp_bpf_update_proto` and replaces the socket's `sk_prot` with the tcp_bpf
+  one. Those paths have now stalled unrelated workloads three times (a GitHub
+  runner's log stream, tailscaled's control-channel long poll; forensics in
+  T-20708). After this patch a socket is enrolled only if the process that
+  opened it passed `valid_pid`.
+
+  Why the enrolling callback could not just test `valid_pid` itself: it does
+  not run in the owner's context. `BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB` is
+  raised by `tcp_finish_connect` -> `tcp_init_transfer`
+  (net/ipv4/tcp_input.c:6113), i.e. while the SYN-ACK is processed — normally
+  NET_RX softirq on whichever CPU took the packet, so
+  `bpf_get_current_pid_tgid()` there is the interrupted task, or 0 for the idle
+  task. Testing discovery there would deny instrumented processes at random.
+  `BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB` is further removed still: it fires for
+  a child socket no task has returned from `accept()` yet.
+
+  The decision therefore moves to `BPF_SOCK_OPS_TCP_CONNECT_CB`, raised from
+  the first line of `tcp_connect()` (net/ipv4/tcp_output.c:3952), which is
+  reached only through `sk_prot->connect` from `connect(2)` — or
+  `tcp_sendmsg_fastopen()` for TFO — so the current task is by construction the
+  process dialling. It records a byte in a new `sk_discovery_ok` SK_STORAGE,
+  and the established callback enrolls only marked sockets. No new attachment:
+  the sockops program was already there, this is one more `case`. The passive
+  path is untouched, so inbound TCP-option parsing on server sockets behaves
+  exactly as before.
+
+  Prevention rather than eviction, because eviction is not available. Removing
+  a socket from a sockhash means `bpf_map_delete_elem`, and since v6.10 the
+  verifier only permits that for the program types in `may_update_sockmap()` —
+  kernel commit 98e948fb60d4 ("bpf: Allow delete from sockmap/sockhash only if
+  update is allowed"), which folded delete into the update allow-list after
+  syzkaller hit the lock inversion of ff9105993240. `BPF_PROG_TYPE_SK_MSG` is
+  not on that list, so `obi_packet_extender` — the one program that always runs
+  in the sender's task context — cannot evict the socket it was called for; the
+  program fails to load outright with `cannot pass map_type 18 into func
+  bpf_map_delete_elem`, which would silently disable the injector. Not
+  enrolling is also strictly better than evicting: there is no window at all,
+  rather than "off the tcp_bpf path after the first egress message".
+
+  Exposure window: none for sockets opened while OBI is attached. A socket
+  whose `connect()` predates OBI, or predates the discovery of its process,
+  carries no mark and is simply never enrolled — losing propagation, never
+  corrupting. The `AllowPID` backfill is what recovers those, and it is scoped
+  the same way: `iter/tcp` walks an entire network namespace and `struct sock`
+  records no owner, so `AllowPID` now publishes the discovered pid's own socket
+  inodes — read from its `/proc/<pid>/fd` links, matched in BPF against
+  `sk->sk_socket->file->f_inode->i_ino` — into `iter_allowed_socks` for the
+  duration of the walk. That also makes the walk per-pid rather than per-netns,
+  since the allow-set is per-pid.
+
+  Verifier cost: the whole sk_msg chain is byte-identical to 011
+  (`obi_packet_extender` stays at 851 instructions, every tail-called program
+  unchanged); `obi_sockmap_tracker` goes 1801 -> 2195 and `obi_sk_iter_tcp`
+  428 -> 468.
+
+  `ebpf/tests/egress-integrity` grows a `sockhash-scoping` scenario that proves
+  it with a control: a second copy of the harness binary, at a path discovery
+  does not match and reparented onto init (`valid_pid` deliberately inherits
+  from the parent, so a direct child would be instrumented and rightly so),
+  connects and reports its socket cookie before sending. `sock_dir` is then
+  read through `bpf(2)` and must contain the harness's own socket and not the
+  bystander's, both at establishment and after the bystander's one request —
+  which must also arrive byte-identical and without a Traceparent, while the
+  harness's identical request gets one.

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -137,3 +137,114 @@ Currently contains patches:
   bystander's, both at establishment and after the bystander's one request —
   which must also arrive byte-identical and without a Traceparent, while the
   harness's identical request gets one.
+* 013-deny-before-parent-fallback.patch
+  Make discovery's exclusions real in the kernel. `valid_pid()` (bpf/pid/pid.h)
+  looks the calling process up in the allow bitmap and, on a miss, retries with
+  its namespaced parent pid. That fallback is deliberate — it is how OBI follows
+  an instrumented process into its workers, and 012's scenario depends on it
+  staying intact — but userspace only ever *declined to add* an excluded process
+  to the allow-list; nothing ever told BPF what had been excluded. So with
+  `open_ports` discovery, where pid 1 is routinely instrumented and every
+  process on the machine descends from pid 1, `exclude_instrument` meant nothing
+  below the userspace pipeline. Observed live before this patch: an excluded
+  `tailscaled` enrolled 2/2 into the sockhash, because systemd was discovered
+  through open_ports.
+
+  Semantics. A new `denied_pids` hash, keyed exactly like the allow-list
+  (`pid_data_t` = namespaced pid + pid-namespace inode), is consulted in
+  `valid_pid` ahead of both the allow bitmap and the parent fallback. Only the
+  caller's *own* identity is looked up: a denied parent does not taint its
+  children, because a supervisor the user excluded may legitimately fork the
+  workload they asked for, and that workload has its own allow-list entry.
+  Allowed processes and their non-excluded children are unaffected — the
+  fork-following fallback is untouched, and the per-event hot path is unchanged
+  because a `pid_cache` hit still returns before any of this.
+
+  An exact hash rather than a second copy of the bitmap: `valid_pids` hashes
+  (ns, pid) into 192053 bits with no collision resolution, which upstream can
+  afford because a collision there fails *open* and merely lets an extra process
+  through. The same collision in a deny structure fails closed and would
+  silently stop instrumenting a process the user did select.
+
+  Who publishes it. The criteria matcher (`filterCreated` in
+  pkg/appolly/discover/matcher.go) is the only component that evaluates
+  `exclude_instrument`, and the only one that ever sees the processes it drops:
+  an excluded process never becomes an Instrumentable, so it never reaches the
+  attacher and `BlockPID` could not carry this. It publishes when a process
+  matches an exclusion and retracts when the same pid matches the criteria
+  instead; `filterDeleted` retracts on exit, because pids are reused and a
+  denial that outlived its process would silently stop instrumenting the next
+  owner. The keys are every NSpid level of the process under its pid-namespace
+  inode, exactly as `PIDsFilter.addPID()` records the allow side, so the two
+  sides agree whichever level the kernel derives. The map is reached by name
+  through `EBPFEventContext.EBPFMaps` — the agent-wide store of
+  OBI_PIN_INTERNAL maps that `ResolveMaps()` fills — which is one map object
+  shared by every collection that includes pid.h, with a lifetime independent of
+  any single ProcessTracer.
+
+  Each denial also evicts the pid from `pid_cache`, and that is not
+  housekeeping. `pid_cache` is a positive memo of a `valid_pid` pass, consulted
+  before anything else; an excluded process that made egress before discovery
+  reached it was accepted on its parent's ticket and cached, so publishing the
+  denial alone would change nothing for that process for as long as the entry
+  lives. The eviction is what makes the cheap check order safe.
+
+  Residual staleness, all of it fail-open, and none of it removable without
+  matching executables inside BPF:
+  - Discovery lag. The watcher polls every `discovery.poll_interval` (5s by
+    default; its only BPF accelerator is a `sys_bind` kprobe that forces a port
+    refetch) and holds back processes younger than `discovery.min_process_age`
+    (5s), so a just-`exec`ed excluded process still passes on an ancestor's
+    ticket until it is seen. Measured in the harness: 4.3s for a process that
+    predates OBI, 10.1s for one started mid-run.
+  - Pid reuse within one poll interval. If an excluded pid dies and the number
+    is taken by another process before the next poll, the watcher reports
+    neither the exit nor the creation and the denial stands for the new owner.
+    That direction loses instrumentation rather than corrupting bytes, the
+    reverse case (an allowed pid reused by an excluded process) is upstream's
+    existing behaviour, and the retraction on any later match closes it as soon
+    as the pipeline sees the pid again.
+  - A process that exits between the poll and the publish has no
+    `/proc/<pid>/{status,ns/pid}` left to read, so nothing is published — and it
+    generates no more egress either.
+  - A full `denied_pids` (3001 entries, sized like `valid_pids`) refuses new
+    denials and logs a warning. It is a plain hash, not an LRU, so an existing
+    denial can never quietly lapse.
+
+  Kernel floor: the only thing new anywhere is one `bpf_map_lookup_elem` on a
+  `BPF_MAP_TYPE_HASH`. The helper is in the unconditional part of
+  `bpf_base_func_proto()` and the map type is as old as BPF maps, so every
+  program type that already compiles `valid_pid` keeps loading; nothing here is
+  younger than the 5.15 support floor. No new program, no new attachment, no new
+  helper, and the per-program map count is unchanged in kind (one more shared
+  map, far below MAX_USED_MAPS). The programs that consult `valid_pid` are
+  generictracer's kprobes/uprobes and tpinjector's sk_msg entry; the Go uprobes
+  are scoped by being attached per discovered executable and their objects come
+  out byte-identical.
+
+  Verifier cost vs 012: `obi_packet_extender` 851 -> 860, every tail-called
+  sk_msg program unchanged, `obi_sockmap_tracker` and `obi_sk_iter_tcp`
+  unchanged. generictracer's programs move by +8..+82 where `valid_pid` is
+  inlined (its largest, `obi_kprobe_tcp_close`, 29506 -> 29516) and a handful
+  shrink by up to 139 as LLVM re-lays them out; the collection's total falls by
+  58 instructions.
+
+  `ebpf/tests/egress-integrity` grows a `deny-child` scenario, with a control on
+  both sides. The instrumented harness spawns a *direct* child — no reparenting,
+  unlike 012's bystander, so its parent is genuinely allowed — running a copy of
+  the payload at `/tmp/deny-child`, which run-under-obi.sh excludes in the OBI
+  config it composes. The child announces its pid and waits before opening any
+  socket, because `valid_pid` is consulted at `connect()` time in
+  `obi_kprobe_tcp_connect`: it is released only once its exclusion is visible in
+  `denied_pids`, so the scenario waits on an observable rather than a sleep.
+  Then its one HTTP/1.1 request must arrive byte-identical and without a
+  Traceparent, its socket must be absent from `sock_dir` both at establishment
+  and after that request, while the parent's identical request in the same
+  scenario gets a Traceparent and the parent's socket is enrolled — and the
+  parent must not itself be in `denied_pids`. run-under-obi.sh also starts an
+  excluded process *before* OBI, which is the production shape of the bug and
+  the only way to exercise the publisher's deferral, since the first discovery
+  poll runs before any BPF collection exists; its exclusion must reach the map
+  too. Against pristine+008..012 the scenario reports all four differences from
+  one run: the child's socket enrolled in `sock_dir`, one Traceparent on its
+  request, 61 bytes arriving as 131, and the socket still enrolled afterwards.

--- a/ebpf/tests/egress-integrity/deny_child.go
+++ b/ebpf/tests/egress-integrity/deny_child.go
@@ -1,0 +1,451 @@
+package main
+
+// Scenario proving that a discovery exclusion beats the pid filter's parent
+// fallback.
+//
+// valid_pid() (bpf/pid/pid.h) checks the allow-list for the calling process
+// and, on a miss, retries with its parent. That fallback is how OBI follows an
+// instrumented process into its workers, and the sockhash-scoping scenario
+// relies on it being intact. But it also let a process the user *excluded*
+// through on an ancestor's ticket: userspace only ever declined to add such a
+// process to the allow-list, and never told the kernel it was excluded. With
+// `open_ports` discovery pid 1 is routinely instrumented and everything
+// descends from pid 1, so `exclude_instrument` meant nothing in the kernel.
+// Patch 013 publishes the exclusions into `denied_pids` and consults them
+// first.
+//
+// The subject here is therefore a *direct* child of the instrumented harness —
+// no reparenting, unlike the sockhash-scoping bystander — running a copy of
+// this binary at a path the CI config excludes. Its parent is allowed, it is
+// not, and the two must not be confused.
+//
+// The child announces its pid and waits before it opens any socket. That
+// ordering is the point: valid_pid() is consulted in obi_kprobe_tcp_connect at
+// connect() time, so a socket dialled before discovery published the exclusion
+// would have been enrolled into the sockhash for the rest of its life. The
+// harness releases the child only once the exclusion is visible in
+// `denied_pids`, which also makes the scenario wait on an observable rather
+// than on a sleep. Against a build without the map (008..012) it falls back to
+// waiting out the discovery window, and then fails on the assertions, which is
+// what makes it a negative control rather than a tautology.
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// linux/bpf.h
+	bpfMapTypeHash = 1
+
+	deniedPidsMapName = "denied_pids"
+
+	// A path the harness's own discovery criterion (*egress-integrity*) does
+	// not match and run-under-obi.sh excludes explicitly.
+	denyChildExe = "/tmp/deny-child"
+
+	// Written by run-under-obi.sh for the process it starts before OBI, at a
+	// path the same exclusion matches.
+	denyChildEarlyPIDFile = "/tmp/deny-child-early.pid"
+
+	denyChildRequest  = "GET /deny-child HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"
+	denyParentRequest = "GET /deny-parent HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"
+
+	// Discovery has to notice the child first: the watcher polls every
+	// discovery.poll_interval (5s by default) and skips processes younger than
+	// discovery.min_process_age (5s), so ~10s is expected. The cap is the
+	// margin over that, kept under the harness watchdog.
+	denyPublishTimeout = 45 * time.Second
+	denyPublishPoll    = 250 * time.Millisecond
+
+	// Used only when `denied_pids` does not exist, i.e. against a pre-013 OBI:
+	// long enough that the child is certainly discovered and excluded in
+	// userspace, so the failure that follows is about the kernel honouring it.
+	denyPublishWindow = 25 * time.Second
+)
+
+// denyChild is the excluded subject: a copy of this binary at an excluded path,
+// started as a plain child of the instrumented harness and left there.
+func denyChild(port int) error {
+	// Announced before any socket exists, so the harness can wait for the
+	// exclusion to reach BPF before this process dials.
+	if _, err := fmt.Printf("ready pid %d\n", os.Getpid()); err != nil {
+		return err
+	}
+	if err := awaitDenyGate(); err != nil {
+		return fmt.Errorf("waiting to dial: %w", err)
+	}
+
+	conn, err := rawDial(port)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	cookie, err := socketCookie(conn.fd)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Printf("cookie %d\n", cookie); err != nil {
+		return err
+	}
+	if err := awaitDenyGate(); err != nil {
+		return fmt.Errorf("waiting to send: %w", err)
+	}
+
+	if err := writeAll(conn, []byte(denyChildRequest)); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if line != "HTTP/1.1 204 No Content\r\n" {
+		return fmt.Errorf("bad server status line %q", line)
+	}
+	if err := readHeader(reader); err != nil {
+		return err
+	}
+	if _, err := fmt.Println("sent"); err != nil {
+		return err
+	}
+
+	// Hold the socket open so the harness can sample sock_dir again; it closes
+	// our stdin when it is done.
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	return nil
+}
+
+func awaitDenyGate() error {
+	gate := make([]byte, 1)
+	_, err := io.ReadFull(os.Stdin, gate)
+	return err
+}
+
+// denyKeyFor builds the denied_pids key OBI publishes for a pid: pid_data_t
+// {u32 nspid; u32 ns}, which on the little-endian architectures OBI supports
+// is the namespaced pid in the low half of the 8-byte key and the pid
+// namespace inode in the high half.
+//
+// The harness shares this container's pid namespace with OBI and with the
+// child, so the pid it knows is the namespaced one, and /proc/<pid>/ns/pid is
+// the same link OBI reads (procs.FindNamespace). Comparing the whole key keeps
+// the check exact: a match cannot be some other denied process's entry.
+func denyKeyFor(pid int) (uint64, error) {
+	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", pid))
+	if err != nil {
+		return 0, err
+	}
+	openIdx, closeIdx := strings.LastIndex(link, "["), strings.LastIndex(link, "]")
+	if openIdx < 0 || closeIdx < openIdx {
+		return 0, fmt.Errorf("unexpected pid namespace link %q", link)
+	}
+	ns, err := strconv.ParseUint(link[openIdx+1:closeIdx], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("unexpected pid namespace link %q: %w", link, err)
+	}
+
+	return uint64(ns)<<32 | uint64(uint32(pid)), nil
+}
+
+// deniedPIDs reports the published exclusions, and whether the map exists at
+// all: it does not on an OBI built without patch 013.
+func deniedPIDs() (keys map[uint64]struct{}, haveMap bool, err error) {
+	return bpfMapKeys(deniedPidsMapName, bpfMapTypeHash)
+}
+
+// waitForDenial blocks until pid's exclusion is in denied_pids, reporting how
+// long that took and how many entries the map holds, because "it was already
+// there" and "it arrived" are different facts and only the run can tell them
+// apart.
+func waitForDenial(pid int) (haveMap bool, err error) {
+	want, err := denyKeyFor(pid)
+	if err != nil {
+		return false, err
+	}
+
+	start := time.Now()
+	for {
+		keys, haveMap, err := deniedPIDs()
+		if err != nil {
+			return false, fmt.Errorf("reading %s: %w", deniedPidsMapName, err)
+		}
+		if !haveMap {
+			return false, nil
+		}
+		if _, ok := keys[want]; ok {
+			fmt.Printf("deny-child: exclusion for pid %d published after %s (%d entries in %s)\n",
+				pid, time.Since(start).Round(10*time.Millisecond), len(keys), deniedPidsMapName)
+			return true, nil
+		}
+		if time.Since(start) > denyPublishTimeout {
+			return true, fmt.Errorf("OBI did not exclude pid %d within %s (%d entries in %s)",
+				pid, denyPublishTimeout, len(keys), deniedPidsMapName)
+		}
+		time.Sleep(denyPublishPoll)
+	}
+}
+
+// requireEarlyDenial checks the exclusion of the process run-under-obi.sh
+// starts before OBI. Its denial is recorded during the first discovery poll,
+// which runs before any BPF collection exists, so it is the one that has to
+// survive being published later — and it is the shape the bug had in
+// production: an excluded daemon already running when the agent starts.
+func requireEarlyDenial() error {
+	raw, err := os.ReadFile(denyChildEarlyPIDFile)
+	if errors.Is(err, os.ErrNotExist) {
+		// payload run without the runner
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return fmt.Errorf("bad %s: %w", denyChildEarlyPIDFile, err)
+	}
+
+	haveMap, err := waitForDenial(pid)
+	if err != nil {
+		return fmt.Errorf("process started before OBI: %w", err)
+	}
+	if !haveMap {
+		fmt.Printf("deny-child: no %s map; skipping the pre-OBI exclusion check\n", deniedPidsMapName)
+	}
+
+	return nil
+}
+
+//nolint:gocyclo
+func denyChildScenario(selfcheck bool) error {
+	// SO_COOKIE and the BPF maps only exist on Linux; local darwin selfcheck
+	// runs the other scenarios and CI's Linux selfcheck covers this one.
+	if runtime.GOOS != "linux" {
+		fmt.Println("deny-child: skipped (Linux-only)")
+		return nil
+	}
+
+	ln, err := rawListen()
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	// --- allowed control: this process is the child's parent, and allowed ----
+	allowed, err := rawDial(ln.port)
+	if err != nil {
+		return err
+	}
+	defer allowed.Close()
+	allowedCookie, err := socketCookie(allowed.fd)
+	if err != nil {
+		return err
+	}
+	allowedServer, err := ln.accept()
+	if err != nil {
+		return err
+	}
+	defer allowedServer.Close()
+
+	allowedRecorder := &recordingConn{rawConn: allowedServer}
+	if err := writeAll(allowed, []byte(denyParentRequest)); err != nil {
+		return fmt.Errorf("parent client write: %w", err)
+	}
+	parentTPs, err := readRequest(bufio.NewReader(allowedRecorder), allowedRecorder)
+	if err != nil {
+		return fmt.Errorf("parent server read: %w", err)
+	}
+	allowedReader := bufio.NewReader(allowed)
+	if _, err := allowedReader.ReadString('\n'); err != nil {
+		return err
+	}
+	if err := readHeader(allowedReader); err != nil {
+		return err
+	}
+
+	wantParentTPs := 1
+	if selfcheck {
+		wantParentTPs = 0
+	}
+	if parentTPs != wantParentTPs {
+		return fmt.Errorf("parent process: %d Traceparents on its request, want %d", parentTPs, wantParentTPs)
+	}
+
+	// --- an excluded process that predates OBI ------------------------------
+	if !selfcheck {
+		if err := requireEarlyDenial(); err != nil {
+			return err
+		}
+	}
+
+	// --- the excluded direct child ------------------------------------------
+	if err := copySelfTo(denyChildExe); err != nil {
+		return fmt.Errorf("staging deny-child: %w", err)
+	}
+	defer os.Remove(denyChildExe)
+
+	gateR, gateW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer gateW.Close()
+	reportR, reportW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer reportR.Close()
+
+	// Started and deliberately not waited for: this process has to remain its
+	// parent, because an allowed parent is exactly what the scenario is about.
+	child := exec.Command(denyChildExe, "-deny-child", strconv.Itoa(ln.port))
+	child.Stdin = gateR
+	child.Stdout = reportW
+	child.Stderr = os.Stderr
+	err = child.Start()
+	_ = gateR.Close()
+	_ = reportW.Close()
+	if err != nil {
+		return fmt.Errorf("starting deny-child: %w", err)
+	}
+	defer func() {
+		_ = child.Process.Kill()
+		_ = child.Wait()
+	}()
+
+	childOut := bufio.NewReader(reportR)
+	line, err := childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading deny-child readiness: %w", err)
+	}
+	childPID := 0
+	if _, err := fmt.Sscanf(line, "ready pid %d", &childPID); err != nil {
+		return fmt.Errorf("bad deny-child readiness line %q: %w", line, err)
+	}
+	if childPID != child.Process.Pid {
+		return fmt.Errorf("deny-child reported pid %d, started %d", childPID, child.Process.Pid)
+	}
+
+	// --- wait for the exclusion to reach the kernel -------------------------
+	haveDenyMap := false
+	if !selfcheck {
+		haveDenyMap, err = waitForDenial(childPID)
+		if err != nil {
+			return err
+		}
+		if !haveDenyMap {
+			// No denied_pids map: an OBI without patch 013. Give discovery the
+			// same chance to see the child, then let the assertions below say
+			// what that build does with it.
+			fmt.Printf("deny-child: no %s map; waiting out the discovery window (%s)\n",
+				deniedPidsMapName, denyPublishWindow)
+			time.Sleep(denyPublishWindow)
+		}
+	}
+
+	// --- release the dial ---------------------------------------------------
+	if _, err := gateW.Write([]byte("g")); err != nil {
+		return err
+	}
+	line, err = childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading deny-child cookie: %w", err)
+	}
+	var childCookie uint64
+	if _, err := fmt.Sscanf(line, "cookie %d", &childCookie); err != nil {
+		return fmt.Errorf("bad deny-child cookie line %q: %w", line, err)
+	}
+	if childCookie == allowedCookie {
+		return errors.New("socket cookies collided; the membership check would be meaningless")
+	}
+
+	childServer, err := ln.accept()
+	if err != nil {
+		return err
+	}
+	defer childServer.Close()
+	childRecorder := &recordingConn{rawConn: childServer}
+
+	// Failures from here on are collected rather than returned one at a time.
+	// Against an OBI that does not honour the exclusion every consequence is
+	// worth seeing from a single run: the socket enrolled into the sockhash,
+	// the Traceparent spliced in, and the bytes that changed because of it.
+	var problems []error
+
+	// --- at establishment: the parent's socket is enrolled, the child's is not
+	before, haveSockDir, err := sockDirCookies()
+	if err != nil {
+		return fmt.Errorf("reading sock_dir: %w", err)
+	}
+	if !haveSockDir && !selfcheck {
+		return errors.New("no sock_dir SOCKHASH found; tpinjector is not enrolling anything")
+	}
+	if haveSockDir {
+		problems = append(problems,
+			requireMembership("at establishment", before, allowedCookie, true),
+			requireMembership("at establishment", before, childCookie, false))
+	}
+
+	// --- release the child's one request ------------------------------------
+	if _, err := gateW.Write([]byte("g")); err != nil {
+		return err
+	}
+	childTPs, err := readRequest(bufio.NewReader(childRecorder), childRecorder)
+	if err != nil {
+		return fmt.Errorf("deny-child server read: %w", err)
+	}
+	if childTPs != 0 {
+		problems = append(problems, fmt.Errorf(
+			"excluded child's request carried %d Traceparents on its allowed parent's ticket", childTPs))
+	}
+	if err := byteDiff([]byte(denyChildRequest), childRecorder.read.Bytes()); err != nil {
+		problems = append(problems, fmt.Errorf("excluded child's request mutated: %w", err))
+	}
+
+	done, err := childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("waiting for deny-child: %w", err)
+	}
+	if done != "sent\n" {
+		return fmt.Errorf("unexpected deny-child output %q", done)
+	}
+
+	// --- after egress: still only the parent's socket -----------------------
+	if haveSockDir {
+		after, _, err := sockDirCookies()
+		if err != nil {
+			return fmt.Errorf("re-reading sock_dir: %w", err)
+		}
+		problems = append(problems,
+			requireMembership("after child egress", after, childCookie, false),
+			requireMembership("after child egress", after, allowedCookie, true))
+	}
+
+	// Proven, not assumed: the child was denied by name, and its parent stayed
+	// allowed throughout. Without the second half the scenario would also pass
+	// on a build that simply stopped instrumenting anything.
+	if haveDenyMap {
+		keys, _, err := deniedPIDs()
+		if err != nil {
+			return err
+		}
+		self, err := denyKeyFor(os.Getpid())
+		if err != nil {
+			return err
+		}
+		if _, denied := keys[self]; denied {
+			problems = append(problems, fmt.Errorf(
+				"the instrumented parent (pid %d) is in %s", os.Getpid(), deniedPidsMapName))
+		}
+	}
+
+	return errors.Join(problems...)
+}

--- a/ebpf/tests/egress-integrity/go.mod
+++ b/ebpf/tests/egress-integrity/go.mod
@@ -1,0 +1,3 @@
+module egress-integrity
+
+go 1.23.0

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -13,27 +13,44 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
-const traceparentSize = 70
+const (
+	traceparentSize = 70
+	ioTimeout       = 10 * time.Second
+	watchdogTimeout = 120 * time.Second
+)
 
-var traceparentLine = regexp.MustCompile(`^Traceparent: 00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\r\n$`)
+var (
+	traceparentLine  = regexp.MustCompile(`^Traceparent: 00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\r\n$`)
+	progressScenario atomic.Value
+	progressSent     atomic.Int64
+	progressReceived atomic.Int64
+)
 
 type recordingConn struct {
 	net.Conn
+	clientSide   bool
 	read, written bytes.Buffer
 }
 
 func (c *recordingConn) Read(p []byte) (int, error) {
 	n, err := c.Conn.Read(p)
 	c.read.Write(p[:n])
+	if !c.clientSide {
+		progressReceived.Add(int64(n))
+	}
 	return n, err
 }
 
 func (c *recordingConn) Write(p []byte) (int, error) {
 	n, err := c.Conn.Write(p)
 	c.written.Write(p[:n])
+	if c.clientSide {
+		progressSent.Add(int64(n))
+	}
 	return n, err
 }
 
@@ -46,10 +63,26 @@ type exchange struct {
 	serverValue   any
 }
 
-func runExchange(server func(*recordingConn) (any, error), client func(*recordingConn) error) (exchange, error) {
+func setConnDeadlines(c net.Conn) error {
+	deadline := time.Now().Add(ioTimeout)
+	if err := c.SetReadDeadline(deadline); err != nil {
+		return fmt.Errorf("set read deadline: %w", err)
+	}
+	if err := c.SetWriteDeadline(deadline); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
+	return nil
+}
+
+func exchangeError(name, side string, expected int, err error) error {
+	return fmt.Errorf("%s %s failed: client wrote %d bytes; server received %d/%d expected bytes: %w",
+		name, side, progressSent.Load(), progressReceived.Load(), expected, err)
+}
+
+func runExchange(name string, expected int, server func(*recordingConn) (any, error), client func(*recordingConn) error) (exchange, error) {
 	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
-		return exchange{}, err
+		return exchange{}, exchangeError(name, "listen", expected, err)
 	}
 	defer ln.Close()
 
@@ -66,7 +99,11 @@ func runExchange(server func(*recordingConn) (any, error), client func(*recordin
 			return
 		}
 		rc := &recordingConn{Conn: conn}
-		_ = rc.SetDeadline(time.Now().Add(15 * time.Second))
+		if err := setConnDeadlines(rc); err != nil {
+			_ = rc.Close()
+			serverDone <- serverResult{err: err}
+			return
+		}
 		value, err := server(rc)
 		_ = rc.Close()
 		serverDone <- serverResult{value: value, received: bytes.Clone(rc.read.Bytes()), err: err}
@@ -74,18 +111,21 @@ func runExchange(server func(*recordingConn) (any, error), client func(*recordin
 
 	conn, err := net.DialTimeout("tcp4", ln.Addr().String(), 5*time.Second)
 	if err != nil {
-		return exchange{}, err
+		return exchange{}, exchangeError(name, "dial", expected, err)
 	}
-	rc := &recordingConn{Conn: conn}
-	_ = rc.SetDeadline(time.Now().Add(15 * time.Second))
+	rc := &recordingConn{Conn: conn, clientSide: true}
+	if err := setConnDeadlines(rc); err != nil {
+		_ = rc.Close()
+		return exchange{}, exchangeError(name, "client", expected, err)
+	}
 	clientErr := client(rc)
 	_ = rc.Close()
 	result := <-serverDone
 	if clientErr != nil {
-		return exchange{}, clientErr
+		return exchange{}, exchangeError(name, "client", expected, clientErr)
 	}
 	if result.err != nil {
-		return exchange{}, result.err
+		return exchange{}, exchangeError(name, "server", expected, result.err)
 	}
 	return exchange{sent: bytes.Clone(rc.written.Bytes()), received: result.received, serverValue: result.value}, nil
 }
@@ -143,8 +183,12 @@ func upgradeThenBinary() error {
 		[]byte("GET / HTTP/1.1\r\nopaque DERP payload"),
 		[]byte("POST /h HTTP/1.1\r\nmore opaque payload"),
 	}
+	expected := len(request)
+	for _, payload := range payloads {
+		expected += 5 + len(payload)
+	}
 
-	ex, err := runExchange(func(c *recordingConn) (any, error) {
+	ex, err := runExchange("upgrade-then-binary", expected, func(c *recordingConn) (any, error) {
 		reader := bufio.NewReader(c)
 		if err := readHeader(reader); err != nil {
 			return nil, err
@@ -213,7 +257,7 @@ func rawBinary() error {
 		}
 	}
 
-	ex, err := runExchange(func(c *recordingConn) (any, error) {
+	ex, err := runExchange("raw-binary", want.Len(), func(c *recordingConn) (any, error) {
 		_, err := io.Copy(io.Discard, c)
 		return nil, err
 	}, func(c *recordingConn) error {
@@ -309,8 +353,12 @@ func positiveControl(selfcheck bool) error {
 		[]byte("GET /two HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"),
 		[]byte("POST /three HTTP/1.1\r\nHost: x\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\nhello\x00world"),
 	}
+	expected := 0
+	for _, request := range requests {
+		expected += len(request)
+	}
 
-	ex, err := runExchange(func(c *recordingConn) (any, error) {
+	ex, err := runExchange("positive-control", expected, func(c *recordingConn) (any, error) {
 		return receiveRequests(c, len(requests))
 	}, func(c *recordingConn) error {
 		ack := []byte{0}
@@ -385,6 +433,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	progressScenario.Store("startup")
+	watchdog := time.AfterFunc(watchdogTimeout, func() {
+		fmt.Fprintf(os.Stderr, "watchdog timeout after %s: scenario=%s client-written=%d server-received=%d\n",
+			watchdogTimeout, progressScenario.Load(), progressSent.Load(), progressReceived.Load())
+		os.Exit(1)
+	})
+	defer watchdog.Stop()
+
 	scenarios := []struct {
 		name string
 		run  func() error
@@ -394,6 +450,9 @@ func main() {
 		{"positive-control", func() error { return positiveControl(*selfcheck) }},
 	}
 	for _, scenario := range scenarios {
+		progressScenario.Store(scenario.name)
+		progressSent.Store(0)
+		progressReceived.Store(0)
 		if err := scenario.run(); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", scenario.name, err)
 			os.Exit(1)

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -453,6 +453,7 @@ func main() {
 		progressScenario.Store(scenario.name)
 		progressSent.Store(0)
 		progressReceived.Store(0)
+		fmt.Printf("RUN %s\n", scenario.name)
 		if err := scenario.run(); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", scenario.name, err)
 			os.Exit(1)

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -560,6 +560,7 @@ func main() {
 	startFile := flag.String("start-file", "", "wait for this file before opening sockets")
 	bystanderPort := flag.Int("bystander", 0, "internal: run as the non-discovered client of sockhash-scoping")
 	bystanderSpawner := flag.Int("bystander-spawner", 0, "internal: pid of the process that reparented us")
+	denyChildPort := flag.Int("deny-child", 0, "internal: run as the excluded direct child of deny-child")
 	flag.Parse()
 
 	// The sockhash-scoping scenario re-executes this binary from a path OBI's
@@ -573,6 +574,16 @@ func main() {
 		}
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "bystander:", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// The deny-child scenario spawns this binary from an excluded path as a
+	// plain child of the instrumented harness; that copy takes this branch.
+	if *denyChildPort != 0 {
+		if err := denyChild(*denyChildPort); err != nil {
+			fmt.Fprintln(os.Stderr, "deny-child:", err)
 			os.Exit(1)
 		}
 		return
@@ -599,6 +610,7 @@ func main() {
 		{"raw-binary", rawBinary},
 		{"positive-control", func() error { return positiveControl(*selfcheck) }},
 		{"sockhash-scoping", func() error { return sockhashScoping(*selfcheck) }},
+		{"deny-child", func() error { return denyChildScenario(*selfcheck) }},
 	}
 	for _, scenario := range scenarios {
 		progressScenario.Store(scenario.name)

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -558,7 +558,25 @@ func waitForStartFile(path string) error {
 func main() {
 	selfcheck := flag.Bool("selfcheck", false, "verify the userspace harness without OBI")
 	startFile := flag.String("start-file", "", "wait for this file before opening sockets")
+	bystanderPort := flag.Int("bystander", 0, "internal: run as the non-discovered client of sockhash-scoping")
+	bystanderSpawner := flag.Int("bystander-spawner", 0, "internal: pid of the process that reparented us")
 	flag.Parse()
+
+	// The sockhash-scoping scenario re-executes this binary from a path OBI's
+	// discovery filter does not match; that copy takes this branch.
+	if *bystanderPort != 0 {
+		var err error
+		if *bystanderSpawner != 0 {
+			err = bystander(*bystanderPort, *bystanderSpawner)
+		} else {
+			err = respawnBystander(*bystanderPort)
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "bystander:", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if err := waitForStartFile(*startFile); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -580,6 +598,7 @@ func main() {
 		{"upgrade-then-binary", upgradeThenBinary},
 		{"raw-binary", rawBinary},
 		{"positive-control", func() error { return positiveControl(*selfcheck) }},
+		{"sockhash-scoping", func() error { return sockhashScoping(*selfcheck) }},
 	}
 	for _, scenario := range scenarios {
 		progressScenario.Store(scenario.name)

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const traceparentSize = 70
+
+var traceparentLine = regexp.MustCompile(`^Traceparent: 00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\r\n$`)
+
+type recordingConn struct {
+	net.Conn
+	read, written bytes.Buffer
+}
+
+func (c *recordingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	c.read.Write(p[:n])
+	return n, err
+}
+
+func (c *recordingConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	c.written.Write(p[:n])
+	return n, err
+}
+
+func (c *recordingConn) CloseWrite() error {
+	return c.Conn.(*net.TCPConn).CloseWrite()
+}
+
+type exchange struct {
+	sent, received []byte
+	serverValue   any
+}
+
+func runExchange(server func(*recordingConn) (any, error), client func(*recordingConn) error) (exchange, error) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return exchange{}, err
+	}
+	defer ln.Close()
+
+	type serverResult struct {
+		value    any
+		received []byte
+		err      error
+	}
+	serverDone := make(chan serverResult, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverDone <- serverResult{err: err}
+			return
+		}
+		rc := &recordingConn{Conn: conn}
+		_ = rc.SetDeadline(time.Now().Add(15 * time.Second))
+		value, err := server(rc)
+		_ = rc.Close()
+		serverDone <- serverResult{value: value, received: bytes.Clone(rc.read.Bytes()), err: err}
+	}()
+
+	conn, err := net.DialTimeout("tcp4", ln.Addr().String(), 5*time.Second)
+	if err != nil {
+		return exchange{}, err
+	}
+	rc := &recordingConn{Conn: conn}
+	_ = rc.SetDeadline(time.Now().Add(15 * time.Second))
+	clientErr := client(rc)
+	_ = rc.Close()
+	result := <-serverDone
+	if clientErr != nil {
+		return exchange{}, clientErr
+	}
+	if result.err != nil {
+		return exchange{}, result.err
+	}
+	return exchange{sent: bytes.Clone(rc.written.Bytes()), received: result.received, serverValue: result.value}, nil
+}
+
+func writeAll(w io.Writer, p []byte) error {
+	_, err := io.Copy(w, bytes.NewReader(p))
+	return err
+}
+
+func readHeader(r *bufio.Reader) error {
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if line == "\r\n" {
+			return nil
+		}
+	}
+}
+
+func frame(frameType byte, payload []byte) []byte {
+	header := make([]byte, 5)
+	header[0] = frameType
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+	return append(header, payload...)
+}
+
+func sendFrame(c *recordingConn, frameType byte, payload []byte) error {
+	f := frame(frameType, payload)
+	if err := writeAll(c, f[:5]); err != nil {
+		return err
+	}
+	// Separate writes make the opaque payload begin at sk_msg offset zero.
+	return writeAll(c, f[5:])
+}
+
+func byteDiff(want, got []byte) error {
+	at := 0
+	for at < len(want) && at < len(got) && want[at] == got[at] {
+		at++
+	}
+	if at == len(want) && at == len(got) {
+		return nil
+	}
+	lo := max(0, at-16)
+	return fmt.Errorf("first byte divergence at offset %d (want len=%d, got len=%d)\nwant[%d:]: % x\n got[%d:]: % x",
+		at, len(want), len(got), lo, want[lo:min(len(want), at+32)], lo, got[lo:min(len(got), at+32)])
+}
+
+func upgradeThenBinary() error {
+	request := []byte("GET /derp HTTP/1.1\r\nHost: x\r\nUpgrade: DERP\r\nConnection: Upgrade\r\n\r\n")
+	payloads := [][]byte{
+		{0xde, 0xad, 0xbe, 0xef},
+		[]byte("GET / HTTP/1.1\r\nopaque DERP payload"),
+		[]byte("POST /h HTTP/1.1\r\nmore opaque payload"),
+	}
+
+	ex, err := runExchange(func(c *recordingConn) (any, error) {
+		reader := bufio.NewReader(c)
+		if err := readHeader(reader); err != nil {
+			return nil, err
+		}
+		if err := writeAll(c, []byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: DERP\r\nConnection: Upgrade\r\n\r\n")); err != nil {
+			return nil, err
+		}
+		_, err := io.Copy(io.Discard, reader)
+		return nil, err
+	}, func(c *recordingConn) error {
+		if err := writeAll(c, request); err != nil {
+			return err
+		}
+		if err := readHeader(bufio.NewReader(c)); err != nil {
+			return err
+		}
+		for i, payload := range payloads {
+			if err := sendFrame(c, byte(2+i), payload); err != nil {
+				return err
+			}
+		}
+		return c.CloseWrite()
+	})
+	if err != nil {
+		return err
+	}
+	return byteDiff(ex.sent, ex.received)
+}
+
+func compareWithAllowedTraceparents(want, got []byte, allowedOffsets map[int]bool) error {
+	wi, gi := 0, 0
+	for wi < len(want) {
+		if allowedOffsets[wi] && gi+traceparentSize <= len(got) && traceparentLine.Match(got[gi:gi+traceparentSize]) {
+			gi += traceparentSize
+		}
+		if gi >= len(got) || want[wi] != got[gi] {
+			return byteDiff(want, got)
+		}
+		wi++
+		gi++
+	}
+	if allowedOffsets[wi] && gi+traceparentSize == len(got) && traceparentLine.Match(got[gi:]) {
+		gi += traceparentSize
+	}
+	if gi != len(got) {
+		return byteDiff(want, got)
+	}
+	return nil
+}
+
+func rawBinary() error {
+	payloads := [][]byte{
+		{0x00, 0xff, 0x7f},
+		[]byte("GET /not-http\r\n"),
+		[]byte("POST /h HTTP/1\r\n"),
+		[]byte("GET / HTTP/1.1\r\n"),
+	}
+	var want bytes.Buffer
+	allowed := map[int]bool{}
+	for i, payload := range payloads {
+		want.Write(frame(byte(4+i), payload))
+		if i == len(payloads)-1 {
+			// A byte-perfect request line at sk_msg offset zero is indistinguishable
+			// from HTTP. Injection immediately after it is therefore allowed here.
+			allowed[want.Len()] = true
+		}
+	}
+
+	ex, err := runExchange(func(c *recordingConn) (any, error) {
+		_, err := io.Copy(io.Discard, c)
+		return nil, err
+	}, func(c *recordingConn) error {
+		for i, payload := range payloads {
+			if err := sendFrame(c, byte(4+i), payload); err != nil {
+				return err
+			}
+		}
+		return c.CloseWrite()
+	})
+	if err != nil {
+		return err
+	}
+	return compareWithAllowedTraceparents(ex.sent, ex.received, allowed)
+}
+
+type positiveResult struct {
+	traceparents int
+	bodies       [][]byte
+}
+
+func receiveRequests(c *recordingConn, count int) (positiveResult, error) {
+	reader := bufio.NewReader(c)
+	result := positiveResult{}
+	for range count {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return result, err
+		}
+		if !strings.HasSuffix(line, " HTTP/1.1\r\n") {
+			return result, fmt.Errorf("invalid request line %q", line)
+		}
+		contentLength := 0
+		for {
+			line, err = reader.ReadString('\n')
+			if err != nil {
+				return result, err
+			}
+			if line == "\r\n" {
+				break
+			}
+			if strings.HasPrefix(line, "Traceparent: ") {
+				if !traceparentLine.MatchString(line) {
+					return result, fmt.Errorf("malformed traceparent %q", line)
+				}
+				result.traceparents++
+			}
+			if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+				contentLength, err = strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(strings.ToLower(line), "content-length:")))
+				if err != nil {
+					return result, err
+				}
+			}
+		}
+		body := make([]byte, contentLength)
+		if _, err := io.ReadFull(reader, body); err != nil {
+			return result, err
+		}
+		result.bodies = append(result.bodies, body)
+		if err := writeAll(c, []byte{0xac}); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func stripTraceparents(raw []byte) ([]byte, int, error) {
+	var clean bytes.Buffer
+	count := 0
+	for len(raw) > 0 {
+		newline := bytes.IndexByte(raw, '\n')
+		if newline < 0 {
+			clean.Write(raw)
+			break
+		}
+		line := raw[:newline+1]
+		raw = raw[newline+1:]
+		if bytes.HasPrefix(line, []byte("Traceparent: ")) {
+			if !traceparentLine.Match(line) {
+				return nil, 0, fmt.Errorf("malformed traceparent %q", line)
+			}
+			count++
+			continue
+		}
+		clean.Write(line)
+	}
+	return clean.Bytes(), count, nil
+}
+
+func positiveControl(selfcheck bool) error {
+	requests := [][]byte{
+		[]byte("GET /one HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"),
+		[]byte("GET /two HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"),
+		[]byte("POST /three HTTP/1.1\r\nHost: x\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\nhello\x00world"),
+	}
+
+	ex, err := runExchange(func(c *recordingConn) (any, error) {
+		return receiveRequests(c, len(requests))
+	}, func(c *recordingConn) error {
+		ack := []byte{0}
+		for _, request := range requests {
+			if err := writeAll(c, request); err != nil {
+				return err
+			}
+			if _, err := io.ReadFull(c, ack); err != nil {
+				return err
+			}
+			if ack[0] != 0xac {
+				return fmt.Errorf("bad server acknowledgement %#x", ack[0])
+			}
+		}
+		return c.CloseWrite()
+	})
+	if err != nil {
+		return err
+	}
+	result, ok := ex.serverValue.(positiveResult)
+	if !ok {
+		return errors.New("missing positive-control server result")
+	}
+	clean, traceparents, err := stripTraceparents(ex.received)
+	if err != nil {
+		return err
+	}
+	if err := byteDiff(ex.sent, clean); err != nil {
+		return fmt.Errorf("request/body mutation after removing Traceparent headers: %w", err)
+	}
+	wantTraceparents := len(requests)
+	if selfcheck {
+		wantTraceparents = 0
+	}
+	if traceparents != wantTraceparents || result.traceparents != wantTraceparents {
+		return fmt.Errorf("Traceparent count: raw=%d parsed=%d, want=%d", traceparents, result.traceparents, wantTraceparents)
+	}
+	wantBodies := [][]byte{nil, nil, []byte("hello\x00world")}
+	for i := range wantBodies {
+		if !bytes.Equal(result.bodies[i], wantBodies[i]) {
+			return fmt.Errorf("request %d body changed: %w", i+1, byteDiff(wantBodies[i], result.bodies[i]))
+		}
+	}
+	return nil
+}
+
+func waitForStartFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for OBI start gate %s", path)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func main() {
+	selfcheck := flag.Bool("selfcheck", false, "verify the userspace harness without OBI")
+	startFile := flag.String("start-file", "", "wait for this file before opening sockets")
+	flag.Parse()
+
+	if err := waitForStartFile(*startFile); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	scenarios := []struct {
+		name string
+		run  func() error
+	}{
+		{"upgrade-then-binary", upgradeThenBinary},
+		{"raw-binary", rawBinary},
+		{"positive-control", func() error { return positiveControl(*selfcheck) }},
+	}
+	for _, scenario := range scenarios {
+		if err := scenario.run(); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", scenario.name, err)
+			os.Exit(1)
+		}
+		fmt.Printf("PASS %s\n", scenario.name)
+	}
+}

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -8,12 +8,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
@@ -21,6 +21,9 @@ const (
 	traceparentSize = 70
 	ioTimeout       = 10 * time.Second
 	watchdogTimeout = 120 * time.Second
+
+	// 204 keeps the response bodyless, so the client only has to consume a head.
+	httpNoContentResponse = "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n"
 )
 
 var (
@@ -30,14 +33,158 @@ var (
 	progressReceived atomic.Int64
 )
 
+// rawConn is a blocking AF_INET socket driven with direct syscalls, deliberately
+// outside Go's netpoller and net.Conn machinery.
+//
+// This is not incidental. OBI attaches uprobes to net.(*netFD).Read/Write for Go
+// executables, and the write uprobe runs *before* the bytes reach the sk_msg
+// verdict program. It marks the connection as having a request in flight, and
+// tpinjector's protocol_detector then refuses it ("already extended before,
+// ignoring this packet"), so no HTTP/1 message on a net.Conn ever reaches the
+// injection path this harness exists to test — neither to be injected into nor
+// to be passed through. Raw syscalls keep the uprobes out of the picture, which
+// is also what the non-Go workloads that depend on sk_msg injection look like.
+type rawConn struct {
+	fd int
+}
+
+func setSocketTimeouts(fd int) error {
+	tv := syscall.NsecToTimeval(ioTimeout.Nanoseconds())
+	if err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv); err != nil {
+		return fmt.Errorf("SO_RCVTIMEO: %w", err)
+	}
+	if err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_SNDTIMEO, &tv); err != nil {
+		return fmt.Errorf("SO_SNDTIMEO: %w", err)
+	}
+	return nil
+}
+
+// The Go runtime preempts threads with signals, so every blocking syscall here
+// has to tolerate EINTR.
+func (c *rawConn) Read(p []byte) (int, error) {
+	for {
+		n, err := syscall.Read(c.fd, p)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		if n == 0 {
+			return 0, io.EOF
+		}
+		return n, nil
+	}
+}
+
+func (c *rawConn) Write(p []byte) (int, error) {
+	written := 0
+	for written < len(p) {
+		n, err := syscall.Write(c.fd, p[written:])
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return written, err
+		}
+		written += n
+	}
+	return written, nil
+}
+
+func (c *rawConn) CloseWrite() error {
+	return syscall.Shutdown(c.fd, syscall.SHUT_WR)
+}
+
+func (c *rawConn) Close() error {
+	return syscall.Close(c.fd)
+}
+
+type rawListener struct {
+	fd   int
+	port int
+}
+
+func rawListen() (*rawListener, error) {
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	if err != nil {
+		return nil, fmt.Errorf("socket: %w", err)
+	}
+	addr := &syscall.SockaddrInet4{Addr: [4]byte{127, 0, 0, 1}}
+	if err := syscall.Bind(fd, addr); err != nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("bind: %w", err)
+	}
+	if err := syscall.Listen(fd, 1); err != nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+	bound, err := syscall.Getsockname(fd)
+	if err != nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("getsockname: %w", err)
+	}
+	in4, ok := bound.(*syscall.SockaddrInet4)
+	if !ok {
+		_ = syscall.Close(fd)
+		return nil, errors.New("listener is not AF_INET")
+	}
+	return &rawListener{fd: fd, port: in4.Port}, nil
+}
+
+func (l *rawListener) accept() (*rawConn, error) {
+	for {
+		fd, _, err := syscall.Accept(l.fd)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("accept: %w", err)
+		}
+		if err := setSocketTimeouts(fd); err != nil {
+			_ = syscall.Close(fd)
+			return nil, err
+		}
+		return &rawConn{fd: fd}, nil
+	}
+}
+
+func (l *rawListener) Close() error {
+	return syscall.Close(l.fd)
+}
+
+func rawDial(port int) (*rawConn, error) {
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	if err != nil {
+		return nil, fmt.Errorf("socket: %w", err)
+	}
+	if err := setSocketTimeouts(fd); err != nil {
+		_ = syscall.Close(fd)
+		return nil, err
+	}
+	addr := &syscall.SockaddrInet4{Port: port, Addr: [4]byte{127, 0, 0, 1}}
+	for {
+		err = syscall.Connect(fd, addr)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		break
+	}
+	if err != nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	return &rawConn{fd: fd}, nil
+}
+
 type recordingConn struct {
-	net.Conn
-	clientSide   bool
+	*rawConn
+	clientSide    bool
 	read, written bytes.Buffer
 }
 
 func (c *recordingConn) Read(p []byte) (int, error) {
-	n, err := c.Conn.Read(p)
+	n, err := c.rawConn.Read(p)
 	c.read.Write(p[:n])
 	if !c.clientSide {
 		progressReceived.Add(int64(n))
@@ -46,7 +193,7 @@ func (c *recordingConn) Read(p []byte) (int, error) {
 }
 
 func (c *recordingConn) Write(p []byte) (int, error) {
-	n, err := c.Conn.Write(p)
+	n, err := c.rawConn.Write(p)
 	c.written.Write(p[:n])
 	if c.clientSide {
 		progressSent.Add(int64(n))
@@ -54,24 +201,9 @@ func (c *recordingConn) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func (c *recordingConn) CloseWrite() error {
-	return c.Conn.(*net.TCPConn).CloseWrite()
-}
-
 type exchange struct {
 	sent, received []byte
-	serverValue   any
-}
-
-func setConnDeadlines(c net.Conn) error {
-	deadline := time.Now().Add(ioTimeout)
-	if err := c.SetReadDeadline(deadline); err != nil {
-		return fmt.Errorf("set read deadline: %w", err)
-	}
-	if err := c.SetWriteDeadline(deadline); err != nil {
-		return fmt.Errorf("set write deadline: %w", err)
-	}
-	return nil
+	serverValue    any
 }
 
 func exchangeError(name, side string, expected int, err error) error {
@@ -80,7 +212,7 @@ func exchangeError(name, side string, expected int, err error) error {
 }
 
 func runExchange(name string, expected int, server func(*recordingConn) (any, error), client func(*recordingConn) error) (exchange, error) {
-	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	ln, err := rawListen()
 	if err != nil {
 		return exchange{}, exchangeError(name, "listen", expected, err)
 	}
@@ -93,31 +225,22 @@ func runExchange(name string, expected int, server func(*recordingConn) (any, er
 	}
 	serverDone := make(chan serverResult, 1)
 	go func() {
-		conn, err := ln.Accept()
+		conn, err := ln.accept()
 		if err != nil {
 			serverDone <- serverResult{err: err}
 			return
 		}
-		rc := &recordingConn{Conn: conn}
-		if err := setConnDeadlines(rc); err != nil {
-			_ = rc.Close()
-			serverDone <- serverResult{err: err}
-			return
-		}
+		rc := &recordingConn{rawConn: conn}
 		value, err := server(rc)
 		_ = rc.Close()
 		serverDone <- serverResult{value: value, received: bytes.Clone(rc.read.Bytes()), err: err}
 	}()
 
-	conn, err := net.DialTimeout("tcp4", ln.Addr().String(), 5*time.Second)
+	conn, err := rawDial(ln.port)
 	if err != nil {
 		return exchange{}, exchangeError(name, "dial", expected, err)
 	}
-	rc := &recordingConn{Conn: conn, clientSide: true}
-	if err := setConnDeadlines(rc); err != nil {
-		_ = rc.Close()
-		return exchange{}, exchangeError(name, "client", expected, err)
-	}
+	rc := &recordingConn{rawConn: conn, clientSide: true}
 	clientErr := client(rc)
 	_ = rc.Close()
 	result := <-serverDone
@@ -317,7 +440,12 @@ func receiveRequests(c *recordingConn, count int) (positiveResult, error) {
 			return result, err
 		}
 		result.bodies = append(result.bodies, body)
-		if err := writeAll(c, []byte{0xac}); err != nil {
+		// A real response, not a one-byte ack. OBI's generic tracer tracks the
+		// request as in flight on this connection and tpinjector refuses a
+		// connection that still has one ("already extended before, ignoring
+		// this packet"), so without a parsable response only the first
+		// keep-alive request on the connection is ever injected into.
+		if err := writeAll(c, []byte(httpNoContentResponse)); err != nil {
 			return result, err
 		}
 	}
@@ -361,16 +489,20 @@ func positiveControl(selfcheck bool) error {
 	ex, err := runExchange("positive-control", expected, func(c *recordingConn) (any, error) {
 		return receiveRequests(c, len(requests))
 	}, func(c *recordingConn) error {
-		ack := []byte{0}
+		reader := bufio.NewReader(c)
 		for _, request := range requests {
 			if err := writeAll(c, request); err != nil {
 				return err
 			}
-			if _, err := io.ReadFull(c, ack); err != nil {
+			line, err := reader.ReadString('\n')
+			if err != nil {
 				return err
 			}
-			if ack[0] != 0xac {
-				return fmt.Errorf("bad server acknowledgement %#x", ack[0])
+			if line != "HTTP/1.1 204 No Content\r\n" {
+				return fmt.Errorf("bad server status line %q", line)
+			}
+			if err := readHeader(reader); err != nil {
+				return err
 			}
 		}
 		return c.CloseWrite()

--- a/ebpf/tests/egress-integrity/run-under-obi.sh
+++ b/ebpf/tests/egress-integrity/run-under-obi.sh
@@ -41,6 +41,12 @@ mkdir -p /sys/fs/bpf
 if ! grep -q ' /sys/fs/bpf bpf ' /proc/mounts; then
   mount -t bpf bpf /sys/fs/bpf
 fi
+# OBI's FIONREAD compensation attaches syscall tracepoints; without tracefs it
+# fails and OBI then disables context propagation entirely, which the
+# positive-control scenario (rightly) reports as zero Traceparents.
+if ! grep -q ' /sys/kernel/tracing tracefs ' /proc/mounts; then
+  mount -t tracefs tracefs /sys/kernel/tracing
+fi
 
 rm -f "$start_file"
 "$obi" -config "$config" >"$obi_log" 2>&1 &

--- a/ebpf/tests/egress-integrity/run-under-obi.sh
+++ b/ebpf/tests/egress-integrity/run-under-obi.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+obi=$1
+payload=$2
+config=$3
+obi_log=/tmp/obi.log
+payload_log=/tmp/egress-integrity.log
+start_file=/tmp/egress-integrity.start
+obi_pid=
+payload_pid=
+
+cleanup() {
+  status=$?
+  set +e
+  [ -n "$payload_pid" ] && kill "$payload_pid" 2>/dev/null
+  [ -n "$obi_pid" ] && kill "$obi_pid" 2>/dev/null
+  sleep 1
+  [ -n "$payload_pid" ] && kill -9 "$payload_pid" 2>/dev/null
+  [ -n "$obi_pid" ] && kill -9 "$obi_pid" 2>/dev/null
+  if [ "$status" -ne 0 ]; then
+    echo "::group::OBI log"
+    cat "$obi_log"
+    echo "::endgroup::"
+    echo "::group::egress-integrity log"
+    cat "$payload_log"
+    echo "::endgroup::"
+    echo "::group::container dmesg tail"
+    dmesg 2>&1 | tail -n 100
+    echo "::endgroup::"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+# A private cgroup namespace exposes the container cgroup as hierarchy root.
+# OBI attaches sock_ops to this root, so it cannot convert host runner sockets.
+grep -qx '0::/' /proc/1/cgroup
+test -r /sys/kernel/btf/vmlinux
+mkdir -p /sys/fs/bpf
+if ! grep -q ' /sys/fs/bpf bpf ' /proc/mounts; then
+  mount -t bpf bpf /sys/fs/bpf
+fi
+
+rm -f "$start_file"
+"$obi" -config "$config" >"$obi_log" 2>&1 &
+obi_pid=$!
+timeout --signal=TERM --kill-after=10s 150s \
+  "$payload" -start-file "$start_file" >"$payload_log" 2>&1 &
+payload_pid=$!
+
+ready=
+for _ in {1..60}; do
+  if grep -q "tpinjector started" "$obi_log"; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$obi_pid" 2>/dev/null; then
+    echo "OBI exited before tpinjector readiness"
+    exit 1
+  fi
+  sleep 1
+done
+if [ -z "$ready" ]; then
+  echo "timed out waiting for tpinjector readiness"
+  exit 1
+fi
+
+touch "$start_file"
+wait "$payload_pid"
+cat "$payload_log"

--- a/ebpf/tests/egress-integrity/run-under-obi.sh
+++ b/ebpf/tests/egress-integrity/run-under-obi.sh
@@ -9,12 +9,14 @@ payload_log=/tmp/egress-integrity.log
 start_file=/tmp/egress-integrity.start
 obi_pid=
 payload_pid=
+early_pid=
 
 cleanup() {
   status=$?
   set +e
   [ -n "$payload_pid" ] && kill "$payload_pid" 2>/dev/null
   [ -n "$obi_pid" ] && kill "$obi_pid" 2>/dev/null
+  [ -n "$early_pid" ] && kill -9 "$early_pid" 2>/dev/null
   sleep 1
   [ -n "$payload_pid" ] && kill -9 "$payload_pid" 2>/dev/null
   [ -n "$obi_pid" ] && kill -9 "$obi_pid" 2>/dev/null
@@ -47,6 +49,36 @@ fi
 if ! grep -q ' /sys/kernel/tracing tracefs ' /proc/mounts; then
   mount -t tracefs tracefs /sys/kernel/tracing
 fi
+
+# The deny-child scenario needs '*deny-child*' excluded from instrumentation,
+# and it is the runner's job rather than each caller's: the scenario is part of
+# this harness, so its precondition travels with it. Inserted right after the
+# top-level discovery key, at the same indentation as the instrument list the
+# callers set; the grep fails the run loudly if the config had no such block.
+run_config=/tmp/obi-config-with-exclusion.yml
+awk '{ print }
+     /^discovery:[[:space:]]*$/ {
+       print "  exclude_instrument:"
+       print "    - exe_path: \"*deny-child*\""
+     }' "$config" >"$run_config"
+grep -q 'deny-child' "$run_config"
+config=$run_config
+
+# An excluded process that predates OBI. This is the production shape of the
+# bug in T-20708 — an excluded daemon already running when the agent starts —
+# and the only way to exercise the publisher's deferral, because the first
+# discovery poll runs before the first BPF collection exists, so the exclusion
+# is recorded before there is a map to put it in. Any executable will do; only
+# its path has to match the exclusion.
+early_exe=/tmp/deny-child-early
+early_pid_file=/tmp/deny-child-early.pid
+rm -f "$early_pid_file"
+cp /usr/bin/sleep "$early_exe"
+"$early_exe" 600 &
+early_pid=$!
+echo "$early_pid" >"$early_pid_file"
+# keeps bash from printing a job notification when cleanup kills it
+disown "$early_pid"
 
 rm -f "$start_file"
 "$obi" -config "$config" >"$obi_log" 2>&1 &

--- a/ebpf/tests/egress-integrity/run-under-obi.sh
+++ b/ebpf/tests/egress-integrity/run-under-obi.sh
@@ -72,6 +72,19 @@ if [ -z "$ready" ]; then
   exit 1
 fi
 
+# OBI logs a BPF load failure as a warning and carries on with that tracer
+# disabled. If an injector program is the one that failed, every byte-integrity
+# scenario below passes for the wrong reason — nothing is attached that could
+# corrupt anything — so treat it as a hard failure. Typical cause: a tpinjector
+# patch pushing a program past the verifier's complexity limit ("BPF program is
+# too large. Processed 1000001 insn"). Scoped to the injector's own programs so
+# an unrelated optional tracer failing on some kernel does not fail the run.
+if grep -qE "couldn't load tracer.*Obi(PacketExtender|SockmapTracker)" "$obi_log"; then
+  echo "OBI failed to load an injector program; the integrity scenarios would pass vacuously"
+  grep -E "couldn't load tracer.*Obi(PacketExtender|SockmapTracker)" "$obi_log"
+  exit 1
+fi
+
 touch "$start_file"
 wait "$payload_pid"
 cat "$payload_log"

--- a/ebpf/tests/egress-integrity/sockhash_scoping.go
+++ b/ebpf/tests/egress-integrity/sockhash_scoping.go
@@ -1,0 +1,534 @@
+package main
+
+// Scenario proving that OBI's sockhash membership is scoped to discovery.
+//
+// Membership in `sock_dir` is what swaps a socket's protocol ops for tcp_bpf,
+// whose sendmsg/recvmsg stalls are the reason this patch series exists.
+// Upstream enrolls every outgoing socket in the cgroup, because the sockops
+// callback that enrolls (ACTIVE_ESTABLISHED_CB) fires while the SYN-ACK is
+// processed and cannot see the owning process. Patch 012 moves the discovery
+// check to BPF_SOCK_OPS_TCP_CONNECT_CB, which does run in the connecting task,
+// and enrolls only the sockets it marked.
+//
+// The check here is a real experiment with a control, not a bare absence
+// assertion. A second copy of this binary, at a path discovery does not match,
+// connects and reports its socket cookie *before* sending anything; this
+// process's own socket, opened seconds earlier on the same loopback in the same
+// cgroup, is sampled at the same moment. The allowed socket must be in
+// `sock_dir` — if it were not, nothing would be enrolled at all and every
+// byte-integrity scenario in this harness would pass vacuously — and the
+// bystander's must not be, both before and after its one HTTP/1.1 request. That
+// request must also arrive byte-for-byte, without a Traceparent, while the
+// allowed process's identical request gets one.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	// linux/asm-generic/socket.h; generic across the architectures OBI supports
+	soCookie = 57
+
+	// linux/bpf.h
+	bpfMapGetNextKey  = 4
+	bpfMapGetNextID   = 12
+	bpfMapGetFDByID   = 14
+	bpfObjGetInfoByFD = 15
+	bpfMapTypeSockash = 18
+
+	// bpf_map_info: type at 0, name at 24 (BPF_OBJ_NAME_LEN = 16)
+	mapInfoSize     = 128
+	mapInfoNameAt   = 24
+	mapInfoNameLen  = 16
+	sockDirMapName  = "sock_dir"
+	bystanderExe    = "/tmp/bystander-client"
+	bystanderReqFmt = "GET /bystander HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"
+	scopingReqFmt   = "GET /scoping HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"
+)
+
+func socketCookie(fd int) (uint64, error) {
+	var cookie uint64
+	size := uint32(unsafe.Sizeof(cookie))
+	_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT,
+		uintptr(fd), uintptr(syscall.SOL_SOCKET), soCookie,
+		uintptr(unsafe.Pointer(&cookie)), uintptr(unsafe.Pointer(&size)), 0)
+	if errno != 0 {
+		return 0, fmt.Errorf("getsockopt(SO_COOKIE): %w", errno)
+	}
+	return cookie, nil
+}
+
+// The standard library's syscall package has no SYS_BPF on linux/amd64, so the
+// number comes from the kernel's syscall tables directly. Wrong-arch builds
+// fail loudly at the first call rather than issuing some unrelated syscall.
+var sysBPF = map[string]uintptr{"amd64": 321, "arm64": 280}[runtime.GOARCH]
+
+func bpfCall(cmd int, attr unsafe.Pointer, size uintptr) (uintptr, syscall.Errno) {
+	if sysBPF == 0 {
+		panic("no bpf(2) syscall number for GOARCH=" + runtime.GOARCH)
+	}
+	ret, _, errno := syscall.Syscall(sysBPF, uintptr(cmd), uintptr(attr), size)
+	return ret, errno
+}
+
+type bpfAttrID struct {
+	id        uint32
+	nextID    uint32
+	openFlags uint32
+	_         uint32
+}
+
+type bpfAttrInfo struct {
+	bpfFD   uint32
+	infoLen uint32
+	info    uint64
+}
+
+type bpfAttrElem struct {
+	mapFD   uint32
+	_       uint32
+	key     uint64
+	nextKey uint64
+	flags   uint64
+}
+
+// sockDirFDs returns a file descriptor for every SOCKHASH named sock_dir that
+// this process can see. Walking the id space rather than a bpffs pin keeps the
+// harness independent of OBI's pinning configuration, and it is what
+// `bpftool map dump name sock_dir` does — bpftool is not installable in the
+// --network=none container the scenarios run in.
+func sockDirFDs() ([]int, error) {
+	var fds []int
+	id := uint32(0)
+	for {
+		attr := bpfAttrID{id: id}
+		if _, errno := bpfCall(bpfMapGetNextID, unsafe.Pointer(&attr), unsafe.Sizeof(attr)); errno != 0 {
+			// ENOENT ends the walk. EPERM/EACCES means this process may not
+			// enumerate maps at all, which is the selfcheck run on a plain
+			// runner: report "no map" and let the caller decide.
+			if errno == syscall.ENOENT || errno == syscall.EPERM || errno == syscall.EACCES {
+				return fds, nil
+			}
+			for _, fd := range fds {
+				_ = syscall.Close(fd)
+			}
+			return nil, fmt.Errorf("BPF_MAP_GET_NEXT_ID: %w", errno)
+		}
+		id = attr.nextID
+
+		get := bpfAttrID{id: id}
+		ret, errno := bpfCall(bpfMapGetFDByID, unsafe.Pointer(&get), unsafe.Sizeof(get))
+		if errno != 0 {
+			// a map can disappear between the two calls
+			continue
+		}
+		fd := int(ret)
+
+		var info [mapInfoSize]byte
+		query := bpfAttrInfo{
+			bpfFD:   uint32(fd),
+			infoLen: mapInfoSize,
+			info:    uint64(uintptr(unsafe.Pointer(&info[0]))),
+		}
+		_, errno = bpfCall(bpfObjGetInfoByFD, unsafe.Pointer(&query), unsafe.Sizeof(query))
+		runtime.KeepAlive(info)
+		if errno != 0 {
+			_ = syscall.Close(fd)
+			continue
+		}
+
+		name := string(bytes.TrimRight(info[mapInfoNameAt:mapInfoNameAt+mapInfoNameLen], "\x00"))
+		if name != sockDirMapName || binary.NativeEndian.Uint32(info[0:4]) != bpfMapTypeSockash {
+			_ = syscall.Close(fd)
+			continue
+		}
+		fds = append(fds, fd)
+	}
+}
+
+// sockDirCookies returns the set of socket cookies currently enrolled in
+// sock_dir, or ok=false when no such map exists (selfcheck runs, where OBI
+// never loaded).
+func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
+	fds, err := sockDirFDs()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(fds) == 0 {
+		return nil, false, nil
+	}
+	defer func() {
+		for _, fd := range fds {
+			_ = syscall.Close(fd)
+		}
+	}()
+
+	cookies = map[uint64]struct{}{}
+	for _, fd := range fds {
+		var key, next uint64
+		haveKey := false
+		// sock_dir holds at most 65535 entries; the bound only guards against a
+		// map being mutated underneath the walk.
+		for range 1 << 17 {
+			attr := bpfAttrElem{
+				mapFD:   uint32(fd),
+				nextKey: uint64(uintptr(unsafe.Pointer(&next))),
+			}
+			if haveKey {
+				attr.key = uint64(uintptr(unsafe.Pointer(&key)))
+			}
+			_, errno := bpfCall(bpfMapGetNextKey, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
+			runtime.KeepAlive(&key)
+			runtime.KeepAlive(&next)
+			if errno == syscall.ENOENT {
+				break
+			}
+			if errno != 0 {
+				return nil, false, fmt.Errorf("BPF_MAP_GET_NEXT_KEY: %w", errno)
+			}
+			cookies[next] = struct{}{}
+			key = next
+			haveKey = true
+		}
+	}
+	return cookies, true, nil
+}
+
+// respawnBystander re-executes the bystander with its pipes and exits, so the
+// process that actually opens a socket is orphaned onto pid 1.
+//
+// The indirection is not ceremony. OBI's discovery filter is inherited:
+// valid_pid() in bpf/pid/pid.h falls back to the namespaced parent pid, so a
+// direct child of the instrumented harness passes the filter — deliberately,
+// that is how OBI follows a process tree into its workers. A bystander forked
+// straight from this process would be enrolled, and rightly so. Reparenting
+// produces a process that is genuinely outside discovery: an exe path
+// discovery does not match, under a parent it does not match either.
+func respawnBystander(port int) error {
+	inner := exec.Command(bystanderExe,
+		"-bystander", strconv.Itoa(port),
+		"-bystander-spawner", strconv.Itoa(os.Getpid()))
+	inner.Stdin = os.Stdin
+	inner.Stdout = os.Stdout
+	inner.Stderr = os.Stderr
+	// deliberately not waited for: exiting here is what orphans it
+	return inner.Start()
+}
+
+// waitForReparent blocks until this process has been handed over to init, so
+// the connect() below cannot race the exit of the process that spawned us and
+// be attributed to the instrumented parent after all. Comparing against the
+// spawner's pid rather than a sampled getppid() keeps it correct when the
+// spawner is already gone by the time we look.
+func waitForReparent(spawner int) error {
+	deadline := time.Now().Add(10 * time.Second)
+	for os.Getppid() == spawner {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("bystander is still a child of %d", spawner)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return nil
+}
+
+// bystander is the detached client: a copy of this binary at a path discovery
+// does not match, reparented away from the instrumented harness. It hands its
+// socket cookie and pid to the harness before sending anything, so the harness
+// can sample sock_dir at the moment upstream OBI would have enrolled it.
+func bystander(port, spawner int) error {
+	if err := waitForReparent(spawner); err != nil {
+		return err
+	}
+
+	conn, err := rawDial(port)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	cookie, err := socketCookie(conn.fd)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Printf("cookie %d pid %d\n", cookie, os.Getpid()); err != nil {
+		return err
+	}
+
+	// Block until the parent has sampled sock_dir. The connection is
+	// established, which is the moment upstream OBI would have enrolled it, and
+	// nothing has been sent yet.
+	gate := make([]byte, 1)
+	if _, err := io.ReadFull(os.Stdin, gate); err != nil {
+		return fmt.Errorf("waiting for parent: %w", err)
+	}
+
+	if err := writeAll(conn, []byte(bystanderReqFmt)); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if line != "HTTP/1.1 204 No Content\r\n" {
+		return fmt.Errorf("bad server status line %q", line)
+	}
+	if err := readHeader(reader); err != nil {
+		return err
+	}
+	if _, err := fmt.Println("sent"); err != nil {
+		return err
+	}
+
+	// Hold the socket open so the parent can sample sock_dir again; the parent
+	// closes our stdin when it is done.
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	return nil
+}
+
+func copySelfTo(path string) error {
+	self, err := os.Open("/proc/self/exe")
+	if err != nil {
+		return err
+	}
+	defer self.Close()
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	dst, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dst, self); err != nil {
+		_ = dst.Close()
+		return err
+	}
+	return dst.Close()
+}
+
+// readRequest consumes one bodyless HTTP/1.1 request, answers 204, and reports
+// how many Traceparent headers it carried.
+func readRequest(r *bufio.Reader, c *recordingConn) (int, error) {
+	traceparents := 0
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return 0, err
+	}
+	if !strings.HasSuffix(line, " HTTP/1.1\r\n") {
+		return 0, fmt.Errorf("invalid request line %q", line)
+	}
+	for {
+		line, err = r.ReadString('\n')
+		if err != nil {
+			return 0, err
+		}
+		if line == "\r\n" {
+			break
+		}
+		if strings.HasPrefix(line, "Traceparent: ") {
+			if !traceparentLine.MatchString(line) {
+				return 0, fmt.Errorf("malformed traceparent %q", line)
+			}
+			traceparents++
+		}
+	}
+
+	return traceparents, writeAll(c, []byte(httpNoContentResponse))
+}
+
+func requireMembership(where string, cookies map[uint64]struct{}, cookie uint64, want bool) error {
+	_, got := cookies[cookie]
+	if got == want {
+		return nil
+	}
+	state := map[bool]string{true: "present", false: "absent"}
+	return fmt.Errorf("%s: socket cookie %d is %s in sock_dir, want %s (%d entries)",
+		where, cookie, state[got], state[want], len(cookies))
+}
+
+func sockhashScoping(selfcheck bool) error {
+	// SO_COOKIE and sock_dir only exist on Linux; local darwin selfcheck runs
+	// the other scenarios and CI's Linux selfcheck covers this one.
+	if runtime.GOOS != "linux" {
+		fmt.Println("sockhash-scoping: skipped (Linux-only)")
+		return nil
+	}
+	ln, err := rawListen()
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	// --- allowed control: a socket owned by this (discovered) process --------
+	allowed, err := rawDial(ln.port)
+	if err != nil {
+		return err
+	}
+	defer allowed.Close()
+	allowedCookie, err := socketCookie(allowed.fd)
+	if err != nil {
+		return err
+	}
+	allowedServer, err := ln.accept()
+	if err != nil {
+		return err
+	}
+	defer allowedServer.Close()
+
+	allowedClient := &recordingConn{rawConn: allowed, clientSide: true}
+	allowedRecorder := &recordingConn{rawConn: allowedServer}
+	if err := writeAll(allowedClient, []byte(scopingReqFmt)); err != nil {
+		return fmt.Errorf("allowed client write: %w", err)
+	}
+	allowedTPs, err := readRequest(bufio.NewReader(allowedRecorder), allowedRecorder)
+	if err != nil {
+		return fmt.Errorf("allowed server read: %w", err)
+	}
+	allowedReader := bufio.NewReader(allowedClient)
+	if _, err := allowedReader.ReadString('\n'); err != nil {
+		return err
+	}
+	if err := readHeader(allowedReader); err != nil {
+		return err
+	}
+
+	wantAllowedTPs := 1
+	if selfcheck {
+		wantAllowedTPs = 0
+	}
+	if allowedTPs != wantAllowedTPs {
+		return fmt.Errorf("allowed process: %d Traceparents on its request, want %d",
+			allowedTPs, wantAllowedTPs)
+	}
+
+	// --- bystander: same code, an exe path discovery does not match ----------
+	if err := copySelfTo(bystanderExe); err != nil {
+		return fmt.Errorf("staging bystander: %w", err)
+	}
+	defer os.Remove(bystanderExe)
+
+	// os.Pipe rather than Cmd.StdinPipe/StdoutPipe: Cmd.Wait closes the pipes it
+	// created, and the process we wait for is only the spawner. These ends have
+	// to outlive it and stay wired to the detached client behind it.
+	gateR, gateW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer gateW.Close()
+	reportR, reportW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer reportR.Close()
+
+	spawner := exec.Command(bystanderExe, "-bystander", strconv.Itoa(ln.port))
+	spawner.Stdin = gateR
+	spawner.Stdout = reportW
+	spawner.Stderr = os.Stderr
+	err = spawner.Start()
+	_ = gateR.Close()
+	_ = reportW.Close()
+	if err != nil {
+		return fmt.Errorf("starting bystander: %w", err)
+	}
+	if err := spawner.Wait(); err != nil {
+		return fmt.Errorf("bystander spawner: %w", err)
+	}
+
+	bystanderPID := 0
+	defer func() {
+		if bystanderPID != 0 {
+			_ = syscall.Kill(bystanderPID, syscall.SIGKILL)
+		}
+	}()
+
+	bystanderServer, err := ln.accept()
+	if err != nil {
+		return err
+	}
+	defer bystanderServer.Close()
+	bystanderRecorder := &recordingConn{rawConn: bystanderServer}
+
+	childOut := bufio.NewReader(reportR)
+	line, err := childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading bystander cookie: %w", err)
+	}
+	var bystanderCookie uint64
+	if _, err := fmt.Sscanf(line, "cookie %d pid %d", &bystanderCookie, &bystanderPID); err != nil {
+		return fmt.Errorf("bad bystander report line %q: %w", line, err)
+	}
+	if bystanderCookie == allowedCookie {
+		return errors.New("socket cookies collided; the membership check would be meaningless")
+	}
+
+	// --- at establishment: only the allowed socket is enrolled ---------------
+	before, haveMap, err := sockDirCookies()
+	if err != nil {
+		return fmt.Errorf("reading sock_dir: %w", err)
+	}
+	if !haveMap && !selfcheck {
+		return errors.New("no sock_dir SOCKHASH found; tpinjector is not enrolling anything")
+	}
+	if haveMap {
+		if err := requireMembership("at establishment", before, allowedCookie, true); err != nil {
+			return err
+		}
+		if err := requireMembership("at establishment", before, bystanderCookie, false); err != nil {
+			return err
+		}
+	}
+
+	// --- release the bystander's one request ---------------------------------
+	if _, err := gateW.Write([]byte("g")); err != nil {
+		return err
+	}
+	bystanderTPs, err := readRequest(bufio.NewReader(bystanderRecorder), bystanderRecorder)
+	if err != nil {
+		return fmt.Errorf("bystander server read: %w", err)
+	}
+	if bystanderTPs != 0 {
+		return fmt.Errorf("bystander request carried %d Traceparents; discovery excluded it", bystanderTPs)
+	}
+	if err := byteDiff([]byte(bystanderReqFmt), bystanderRecorder.read.Bytes()); err != nil {
+		return fmt.Errorf("bystander request mutated: %w", err)
+	}
+
+	done, err := childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("waiting for bystander: %w", err)
+	}
+	if strings.TrimSpace(done) != "sent" {
+		return fmt.Errorf("unexpected bystander output %q", done)
+	}
+
+	// --- after egress: still only the allowed socket -------------------------
+	if haveMap {
+		after, _, err := sockDirCookies()
+		if err != nil {
+			return fmt.Errorf("re-reading sock_dir: %w", err)
+		}
+		if err := requireMembership("after bystander egress", after, bystanderCookie, false); err != nil {
+			return err
+		}
+		if err := requireMembership("after bystander egress", after, allowedCookie, true); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/ebpf/tests/egress-integrity/sockhash_scoping.go
+++ b/ebpf/tests/egress-integrity/sockhash_scoping.go
@@ -6,9 +6,10 @@ package main
 // whose sendmsg/recvmsg stalls are the reason this patch series exists.
 // Upstream enrolls every outgoing socket in the cgroup, because the sockops
 // callback that enrolls (ACTIVE_ESTABLISHED_CB) fires while the SYN-ACK is
-// processed and cannot see the owning process. Patch 012 moves the discovery
-// check to BPF_SOCK_OPS_TCP_CONNECT_CB, which does run in the connecting task,
-// and enrolls only the sockets it marked.
+// processed and cannot see the owning process. Patch 012 makes it consult
+// `sock_pids`, which OBI's tcp_connect kprobe fills in the connecting task's
+// own context and only for processes that pass discovery, and enrolls only the
+// sockets found there.
 //
 // The check here is a real experiment with a control, not a bare absence
 // assertion. A second copy of this binary, at a path discovery does not match,

--- a/ebpf/tests/egress-integrity/sockhash_scoping.go
+++ b/ebpf/tests/egress-integrity/sockhash_scoping.go
@@ -106,12 +106,12 @@ type bpfAttrElem struct {
 	flags   uint64
 }
 
-// sockDirFDs returns a file descriptor for every SOCKHASH named sock_dir that
+// bpfMapFDs returns a file descriptor for every map of this name and type that
 // this process can see. Walking the id space rather than a bpffs pin keeps the
 // harness independent of OBI's pinning configuration, and it is what
 // `bpftool map dump name sock_dir` does — bpftool is not installable in the
 // --network=none container the scenarios run in.
-func sockDirFDs() ([]int, error) {
+func bpfMapFDs(name string, mapType uint32) ([]int, error) {
 	var fds []int
 	id := uint32(0)
 	for {
@@ -151,8 +151,8 @@ func sockDirFDs() ([]int, error) {
 			continue
 		}
 
-		name := string(bytes.TrimRight(info[mapInfoNameAt:mapInfoNameAt+mapInfoNameLen], "\x00"))
-		if name != sockDirMapName || binary.NativeEndian.Uint32(info[0:4]) != bpfMapTypeSockash {
+		got := string(bytes.TrimRight(info[mapInfoNameAt:mapInfoNameAt+mapInfoNameLen], "\x00"))
+		if got != name || binary.NativeEndian.Uint32(info[0:4]) != mapType {
 			_ = syscall.Close(fd)
 			continue
 		}
@@ -160,11 +160,12 @@ func sockDirFDs() ([]int, error) {
 	}
 }
 
-// sockDirCookies returns the set of socket cookies currently enrolled in
-// sock_dir, or ok=false when no such map exists (selfcheck runs, where OBI
-// never loaded).
-func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
-	fds, err := sockDirFDs()
+// bpfMapKeys returns the key set of every map of this name and type, or
+// ok=false when no such map exists (selfcheck runs, where OBI never loaded).
+// Both maps this harness reads have 8-byte keys: sock_dir is keyed by socket
+// cookie, denied_pids by pid_data_t (namespaced pid in the low half).
+func bpfMapKeys(name string, mapType uint32) (keys map[uint64]struct{}, ok bool, err error) {
+	fds, err := bpfMapFDs(name, mapType)
 	if err != nil {
 		return nil, false, err
 	}
@@ -177,12 +178,12 @@ func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
 		}
 	}()
 
-	cookies = map[uint64]struct{}{}
+	keys = map[uint64]struct{}{}
 	for _, fd := range fds {
 		var key, next uint64
 		haveKey := false
-		// sock_dir holds at most 65535 entries; the bound only guards against a
-		// map being mutated underneath the walk.
+		// sock_dir holds at most 65535 entries and denied_pids 3001; the bound
+		// only guards against a map being mutated underneath the walk.
 		for range 1 << 17 {
 			attr := bpfAttrElem{
 				mapFD:   uint32(fd),
@@ -200,12 +201,18 @@ func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
 			if errno != 0 {
 				return nil, false, fmt.Errorf("BPF_MAP_GET_NEXT_KEY: %w", errno)
 			}
-			cookies[next] = struct{}{}
+			keys[next] = struct{}{}
 			key = next
 			haveKey = true
 		}
 	}
-	return cookies, true, nil
+	return keys, true, nil
+}
+
+// sockDirCookies returns the set of socket cookies currently enrolled in
+// sock_dir.
+func sockDirCookies() (map[uint64]struct{}, bool, error) {
+	return bpfMapKeys(sockDirMapName, bpfMapTypeSockash)
 }
 
 // respawnBystander re-executes the bystander with its pipes and exits, so the


### PR DESCRIPTION
## Problem

tpinjector decides per egress message whether bytes are HTTP/1, with no socket-lifetime memory, and mutates whatever it approves. The classifier accepts a method prefix plus one target byte, so every protocol that resembles HTTP for an instant is eventually corrupted. #153 fixed two instances (post-upgrade server tunnels, stale scratch buffers); the remaining class is **client-side** upgrade protocols: sk_msg sees egress only, the server's 101 arrives on ingress, so a client socket that upgraded away from HTTP/1 (WebSocket, Tailscale control → Noise, DERP → binary framing) stays injectable forever. On such sockets a reconnect can get a Traceparent spliced into opaque frames, shifting their framing for good — observed as wedged tunnels and `SSL_ERROR_SYSCALL` at the far end.

## Change

**010-default-deny-injection-gate.patch** — invert the trust model:
- new per-socket `SK_STORAGE` byte (`sk_inject_gate`) parks sockets permanently, checked at the top of `obi_packet_extender` before any route that can mutate;
- HTTP/1 injection requires the *current* message to parse as a complete request line (`method SP target SP HTTP/1.<digit> CRLF`) in a freshly filled scratch buffer — binary payloads that merely open `GET /` no longer qualify;
- a request carrying `Upgrade:` parks the socket and is itself passed through untouched (client half of the 101 park from #153);
- `handle_existing_tp_pid` no longer schedules a TCP header option before validating payload — checks first, mutations last;
- confirmed-HTTP/2 chain untouched (already default-deny).

**011-valid-pid-first.patch** — hoist the discovery filter to program entry; upstream checked `valid_pid` only on the fall-through route, so the existing-trace and Go-gRPC routes mutated messages of processes never selected for instrumentation.

**CI** — new `egress-integrity` job: runs the patched OBI on the runner kernel against a recording loopback pair. Upgrade-then-binary and raw-binary scenarios (with adversarial HTTP-lookalike payloads) must be byte-identical; a keep-alive HTTP/1.1 positive control must still receive Traceparent on every request, so an over-blocking gate fails the build instead of silently disabling propagation.

## Verification

- 008→009→010→011 apply cleanly on v0.12.2; `scripts/lint-preempt-guard.sh` passes; eBPF generation and `go test -race ./pkg/internal/ebpf/tpinjector` pass; `go build ./...` (linux) passes.
- Extracted request-line/upgrade parser exercised against 33 cases: all seven methods keep-alive (injectable), binary lookalikes without version token / h2 preface / DERP frames / TLS records (refused), ts2021+DERP+WebSocket upgrade requests incl. casing (parked), `Upgrade:` in a body or as a name prefix (not parked).
- Verifier budget: `obi_packet_extender` 7816 → 7880 insns (+64 net); all other programs byte-identical; no new tail calls; jump table unchanged.
- Harness `-selfcheck` passes without OBI; normal mode without OBI correctly fails the positive control.