### PR TITLE
eBPF: honor exclusions before the PID filter's parent fallback

### DIFF
--- a/ebpf/patches/obi/013-deny-before-parent-fallback.patch
+++ b/ebpf/patches/obi/013-deny-before-parent-fallback.patch
@@ -1,0 +1,569 @@
+diff --git a/bpf/pid/maps/denied_pids.h b/bpf/pid/maps/denied_pids.h
+new file mode 100644
+index 000000000..fb49317f9
+--- /dev/null
++++ b/bpf/pid/maps/denied_pids.h
+@@ -0,0 +1,37 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++#pragma once
++
++#include <bpfcore/vmlinux.h>
++#include <bpfcore/bpf_helpers.h>
++
++#include <common/pin_internal.h>
++
++#include <pid/maps/map_sizing.h>
++
++#include <pid/types/pid_data.h>
++
++// Processes discovery excluded, keyed exactly like the allow-list that
++// pid_matches() reads: the pid as seen inside its own pid namespace, plus that
++// namespace's inode. Filled from userspace by the criteria matcher, which is
++// the only component that evaluates exclude_instrument and the only one that
++// sees the processes it drops.
++//
++// An exact-match hash rather than a second copy of the `valid_pids` bitmap on
++// purpose. That bitmap hashes (ns, pid) into 192053 bits with no collision
++// resolution, which upstream can afford because a collision there fails *open*:
++// some extra process passes the filter. The same collision in a deny structure
++// would fail closed and silently stop instrumenting a process the user did
++// select, so this side has to be exact.
++//
++// Sized like `valid_pids` (1000 processes * 3 namespace levels). A full map
++// means new denials are refused, which userspace reports; it does not evict, so
++// an existing denial can never quietly lapse.
++struct {
++    __uint(type, BPF_MAP_TYPE_HASH);
++    __uint(max_entries, k_max_concurrent_pids);
++    __type(key, pid_data_t);
++    __type(value, u8);
++    __uint(pinning, OBI_PIN_INTERNAL);
++} denied_pids SEC(".maps");
+diff --git a/bpf/pid/pid.h b/bpf/pid/pid.h
+index 7cea1b777..88866c03f 100644
+--- a/bpf/pid/pid.h
++++ b/bpf/pid/pid.h
+@@ -8,6 +8,7 @@
+ 
+ #include <logger/bpf_dbg.h>
+ 
++#include <pid/maps/denied_pids.h>
+ #include <pid/maps/pid_cache.h>
+ #include <pid/maps/valid_pids.h>
+ 
+@@ -66,6 +67,32 @@ static __always_inline u32 valid_pid(u64 id) {
+     if (a_pid != 0) {
+         pid_data_t p_key = {.pid = a_pid, .ns = pid_ns_id};
+ 
++        // Discovery exclusions, honoured before the allow-list and before the
++        // parent fallback below.
++        //
++        // The fallback is deliberate — it is how OBI follows an instrumented
++        // process into its children — but it also let an *excluded* process
++        // pass on its parent's ticket. That is not hypothetical: with
++        // `open_ports` discovery, pid 1 is routinely instrumented, and every
++        // process on the machine descends from pid 1, so `exclude_instrument`
++        // meant nothing in the kernel. It was measured on a real host, where
++        // an excluded tailscaled enrolled into the sockhash 2/2 times.
++        //
++        // Only the process's own identity is consulted. A denied parent does
++        // not taint its children: a supervisor the user excluded may well fork
++        // the workload they asked for, and that workload has its own entry in
++        // the allow-list. So this rejects exactly what userspace rejected, and
++        // the fork-following below is otherwise untouched.
++        //
++        // Placed after the pid_cache lookup, not before it, because the cache
++        // is a positive memo and the publisher evicts the pids it denies (see
++        // pkg/ebpf/common/denied_pids.go). Checking here leaves the hot path
++        // for allowed processes exactly as it was: one cache lookup, no task
++        // walk, no second map.
++        if (bpf_map_lookup_elem(&denied_pids, &p_key)) {
++            return 0;
++        }
++
+         const u8 found_ns_pid = pid_matches(&p_key);
+ 
+         if (found_ns_pid) {
+diff --git a/pkg/appolly/discover/finder.go b/pkg/appolly/discover/finder.go
+index 29ca47b98..5d3159678 100644
+--- a/pkg/appolly/discover/finder.go
++++ b/pkg/appolly/discover/finder.go
+@@ -127,7 +127,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
+ 	), swarm.WithID("LanguageDecoratorProvider"))
+ 
+ 	criteriaFilteredEvents := msgh.QueueFromConfig[[]Event[ProcessMatch]](pf.cfg, "criteriaFilteredEvents")
+-	swi.Add(criteriaMatcherProvider(pf.cfg, langEnrichedEvents, criteriaFilteredEvents, configCriteria, startConfig.dynamicPIDSelector),
++	swi.Add(criteriaMatcherProvider(pf.cfg, langEnrichedEvents, criteriaFilteredEvents, configCriteria, startConfig.dynamicPIDSelector, pf.ebpfEventContext),
+ 		swarm.WithID("CriteriaMatcher"))
+ 	swi.Add(dynamicMatcherProvider(langEnrichedEvents, criteriaFilteredEvents, appDynamicSelector),
+ 		swarm.WithID("DynamicMatcher"))
+diff --git a/pkg/appolly/discover/matcher.go b/pkg/appolly/discover/matcher.go
+index cafef1741..2ffec501d 100644
+--- a/pkg/appolly/discover/matcher.go
++++ b/pkg/appolly/discover/matcher.go
+@@ -38,6 +38,7 @@ func criteriaMatcherProvider(
+ 	output *msg.Queue[[]Event[ProcessMatch]],
+ 	configCriteria []services.Selector,
+ 	dynamicSelector *DynamicPIDSelector,
++	eventContext *ebpfcommon.EBPFEventContext,
+ ) swarm.InstanceFunc {
+ 	instrumenterNamespace, _ := namespaceFetcherFunc(app.PID(osPidFunc()))
+ 	if dynamicSelector != nil {
+@@ -45,8 +46,9 @@ func criteriaMatcherProvider(
+ 		return swarm.DirectInstance(emptyFunc)
+ 	}
+ 
++	log := slog.With("component", "discover.CriteriaMatcher")
+ 	m := &Matcher{
+-		Log:                 slog.With("component", "discover.CriteriaMatcher"),
++		Log:                 log,
+ 		Criteria:            configCriteria,
+ 		ExcludeCriteria:     ExcludingCriteria(cfg),
+ 		LogEnricherCriteria: LogEnricherFindingCriteria(cfg),
+@@ -55,6 +57,7 @@ func criteriaMatcherProvider(
+ 		Output:              output,
+ 		Namespace:           instrumenterNamespace,
+ 		HasHostPidAccess:    hasHostPidAccess(),
++		Denied:              ebpfcommon.NewDeniedPIDs(eventContext, log),
+ 	}
+ 	return swarm.DirectInstance(m.Run)
+ }
+@@ -74,6 +77,9 @@ type Matcher struct {
+ 	Output           *msg.Queue[[]Event[ProcessMatch]]
+ 	Namespace        string
+ 	HasHostPidAccess bool
++	// Denied mirrors the exclusion decisions taken here into the BPF pid
++	// filter, which cannot derive them: see ebpfcommon.DeniedPIDs.
++	Denied *ebpfcommon.DeniedPIDs
+ }
+ 
+ // ProcessMatch matches a found process with the first selection criteria it fulfilled.
+@@ -105,6 +111,10 @@ func (m *Matcher) Run(ctx context.Context) {
+ }
+ 
+ func (m *Matcher) filter(events []Event[ProcessAttrs]) []Event[ProcessMatch] {
++	// Exclusions recorded before the BPF pid filter was loaded still have to
++	// reach it; a no-op once they have.
++	m.Denied.Flush()
++
+ 	var matches []Event[ProcessMatch]
+ 	for _, ev := range events {
+ 		if ev.Type == EventDeleted {
+@@ -173,6 +183,23 @@ func (m *Matcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], bool) {
+ 		return Event[ProcessMatch]{}, false
+ 	}
+ 
++	// Publish the exclusion decision to the BPF pid filter, which cannot take
++	// it: this is the only component that evaluates exclude_instrument, and
++	// excluded processes are dropped here rather than forwarded, so nothing
++	// downstream ever hears about them. Without this, valid_pid()'s parent
++	// fallback keeps letting an excluded process through on an instrumented
++	// ancestor's ticket. The retraction is for pid reuse: this pid may be the
++	// same number a denied process used to have.
++	//
++	// Nothing else about the matching below changes, exclusion included: the
++	// checks in matchCriteria() and on the parent-history route are upstream's
++	// and stay authoritative for this pipeline.
++	if m.isExcluded(&obj, proc) {
++		m.Denied.Deny(obj.pid)
++	} else {
++		m.Denied.Forget(obj.pid)
++	}
++
+ 	if processMatch := m.matchCriteria(obj, proc); processMatch != nil {
+ 		m.ProcessHistory[obj.pid] = *processMatch
+ 
+@@ -200,6 +227,9 @@ func (m *Matcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], bool) {
+ }
+ 
+ func (m *Matcher) filterDeleted(obj ProcessAttrs) (Event[ProcessMatch], bool) {
++	// Denials outlive nothing: the pid is free for reuse the moment it is gone.
++	m.Denied.Forget(obj.pid)
++
+ 	procMatch, ok := m.ProcessHistory[obj.pid]
+ 	if !ok {
+ 		m.Log.Debug("deleted untracked process. Ignoring", "pid", obj.pid)
+diff --git a/pkg/appolly/discover/matcher_test.go b/pkg/appolly/discover/matcher_test.go
+index c4b28eb99..dce07a516 100644
+--- a/pkg/appolly/discover/matcher_test.go
++++ b/pkg/appolly/discover/matcher_test.go
+@@ -50,7 +50,7 @@ func TestMatchersMutuallyExclusive(t *testing.T) {
+ 		}
+ 
+ 		swi := swarm.Instancer{}
+-		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, sel), swarm.WithID("CriteriaMatcher"))
++		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, sel, nil), swarm.WithID("CriteriaMatcher"))
+ 		swi.Add(dynamicMatcherProvider(inQ, outQ, sel.appSignals()), swarm.WithID("DynamicMatcher"))
+ 		runner, err := swi.Instance(t.Context())
+ 		require.NoError(t, err)
+@@ -81,7 +81,7 @@ func TestMatchersMutuallyExclusive(t *testing.T) {
+ 		}
+ 
+ 		swi := swarm.Instancer{}
+-		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, nil), swarm.WithID("CriteriaMatcher"))
++		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, nil, nil), swarm.WithID("CriteriaMatcher"))
+ 		swi.Add(dynamicMatcherProvider(inQ, outQ, nil), swarm.WithID("DynamicMatcher"))
+ 		runner, err := swi.Instance(t.Context())
+ 		require.NoError(t, err)
+@@ -131,7 +131,7 @@ func TestCriteriaMatcher(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -182,7 +182,7 @@ func TestCriteriaMatcherLanguage(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -232,7 +232,7 @@ func TestCriteriaMatcher_Exclude(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -273,7 +273,7 @@ func TestCriteriaMatcher_Exclude_Metadata(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -320,7 +320,7 @@ func TestCriteriaMatcher_MetadataWithDeprecatedPathRegexp(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, criteria, nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, criteria, nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer func() {
+@@ -364,7 +364,7 @@ func TestCriteriaMatcher_MustMatchAllAttributes(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -419,7 +419,7 @@ func TestCriteriaMatcherMissingPort(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -461,7 +461,7 @@ func TestCriteriaMatcherExcludedChildDoesNotInheritParentMatch(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -563,7 +563,7 @@ func TestCriteriaMatcherContainersOnly(t *testing.T) {
+ 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 	require.NoError(t, err)
+ 	go matcherFunc(t.Context())
+ 	defer filteredProcessesQu.Close()
+@@ -702,7 +702,7 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
+ 			discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 			filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 			filteredProcesses := filteredProcessesQu.Subscribe()
+-			matcherFunc, err := criteriaMatcherProvider(&tc.cfg, discoveredProcesses, filteredProcessesQu, FindingCriteria(&tc.cfg), nil)(t.Context())
++			matcherFunc, err := criteriaMatcherProvider(&tc.cfg, discoveredProcesses, filteredProcessesQu, FindingCriteria(&tc.cfg), nil, nil)(t.Context())
+ 			require.NoError(t, err)
+ 			go matcherFunc(t.Context())
+ 			defer filteredProcessesQu.Close()
+@@ -737,7 +737,7 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
+ 		discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 		filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 		filteredProcesses := filteredProcessesQu.Subscribe()
+-		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 		require.NoError(t, err)
+ 		go matcherFunc(t.Context())
+ 		defer filteredProcessesQu.Close()
+@@ -768,7 +768,7 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
+ 		discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+ 		filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+ 		filteredProcesses := filteredProcessesQu.Subscribe()
+-		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++		matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 		require.NoError(t, err)
+ 		go matcherFunc(t.Context())
+ 		defer filteredProcessesQu.Close()
+@@ -957,7 +957,7 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
+ 
+ 	filteredProcesses := filteredProcessesQu.Subscribe()
+ 
+-	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
++	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil, nil)(t.Context())
+ 
+ 	require.NoError(t, err)
+ 
+diff --git a/pkg/appolly/discover/watcher_kube_test.go b/pkg/appolly/discover/watcher_kube_test.go
+index 62304ba4e..38bbab209 100644
+--- a/pkg/appolly/discover/watcher_kube_test.go
++++ b/pkg/appolly/discover/watcher_kube_test.go
+@@ -205,7 +205,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
+       version: "v[0-9]*"
+ `), &pipeConfig))
+ 
+-	swi.Add(criteriaMatcherProvider(&pipeConfig, connectQueue, outputQueue, FindingCriteria(&pipeConfig), nil))
++	swi.Add(criteriaMatcherProvider(&pipeConfig, connectQueue, outputQueue, FindingCriteria(&pipeConfig), nil, nil))
+ 
+ 	nodesRunner, err := swi.Instance(t.Context())
+ 	require.NoError(t, err)
+diff --git a/pkg/ebpf/common/denied_pids.go b/pkg/ebpf/common/denied_pids.go
+new file mode 100644
+index 000000000..03e25c633
+--- /dev/null
++++ b/pkg/ebpf/common/denied_pids.go
+@@ -0,0 +1,224 @@
++// Copyright The OpenTelemetry Authors
++// SPDX-License-Identifier: Apache-2.0
++
++package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common"
++
++import (
++	"errors"
++	"log/slog"
++	"sync"
++
++	"github.com/cilium/ebpf"
++
++	"go.opentelemetry.io/obi/pkg/appolly/app"
++	"go.opentelemetry.io/obi/pkg/internal/procs"
++)
++
++// Both maps are declared in bpf/pid/maps/ with OBI_PIN_INTERNAL, so
++// ResolveMaps() creates exactly one of each per agent and hands the same
++// object to every collection that includes pid.h. Reaching them by name
++// through EBPFEventContext.EBPFMaps is therefore reaching the maps the kernel
++// side actually reads, and it does not depend on which tracer happens to be
++// loaded: the entry outlives any single ProcessTracer.
++const (
++	deniedPIDsMapName = "denied_pids"
++	pidCacheMapName   = "pid_cache"
++)
++
++// deniedPIDKey mirrors pid_data_t (bpf/pid/types/pid_data.h).
++type deniedPIDKey struct {
++	Pid uint32
++	Ns  uint32
++}
++
++// DeniedPIDs publishes discovery's exclusions to the BPF pid filter.
++//
++// valid_pid() (bpf/pid/pid.h) falls back to the parent's pid when a process is
++// not in the allow-list, which is how OBI follows an instrumented process into
++// its children. Nothing told the kernel about the processes discovery had
++// *excluded*, so an excluded process under an instrumented parent — and with
++// `open_ports` discovery, pid 1 is often instrumented — passed the filter
++// anyway. This is the missing half: the criteria matcher records what it
++// excluded here, and valid_pid() rejects those identities before it consults
++// either the allow-list or the parent.
++//
++// Keys are per namespaced pid, exactly as PIDsFilter.addPID() records the
++// allow side: /proc/<pid>/status NSpid lists the process's pid at every level,
++// and BPF only ever derives the innermost one, so publishing all of them makes
++// the two sides agree without having to guess which level the kernel will see.
++type DeniedPIDs struct {
++	mu  sync.Mutex
++	ctx *EBPFEventContext
++	log *slog.Logger
++	// keys published per host pid, kept because the process is gone from /proc
++	// by the time it has to be retracted
++	published map[app.PID][]deniedPIDKey
++	// set when an entry in published is not in the BPF map. The maps do not
++	// exist until the first tracer loads, and the first discovery poll
++	// normally runs before that.
++	backlog bool
++}
++
++// NewDeniedPIDs returns a publisher writing into eventContext's shared maps.
++// A nil eventContext yields a publisher that records nothing, which is what
++// unit tests and the darwin build get.
++func NewDeniedPIDs(eventContext *EBPFEventContext, log *slog.Logger) *DeniedPIDs {
++	return &DeniedPIDs{
++		ctx:       eventContext,
++		log:       log,
++		published: map[app.PID][]deniedPIDKey{},
++	}
++}
++
++// Deny records pid as excluded from instrumentation.
++func (d *DeniedPIDs) Deny(pid app.PID) {
++	if d == nil || d.ctx == nil {
++		return
++	}
++
++	d.mu.Lock()
++	defer d.mu.Unlock()
++
++	if _, known := d.published[pid]; !known {
++		keys := d.keysFor(pid)
++		if len(keys) == 0 {
++			return
++		}
++		d.log.Debug("excluding pid from the BPF pid filter", "pid", pid, "nspids", len(keys))
++		d.published[pid] = keys
++		d.backlog = true
++	}
++
++	if d.backlog {
++		// one failed publish retries every recorded pid, so a denial recorded
++		// before the maps existed cannot be lost
++		d.flushLocked()
++	}
++}
++
++// Forget retracts pid's denial: it exited, or it turned out to match the
++// discovery criteria after all. Pids are reused, and a denial that outlived
++// its process would silently stop instrumenting the next owner.
++func (d *DeniedPIDs) Forget(pid app.PID) {
++	if d == nil || d.ctx == nil {
++		return
++	}
++
++	d.mu.Lock()
++	defer d.mu.Unlock()
++
++	keys, known := d.published[pid]
++	if !known {
++		return
++	}
++	delete(d.published, pid)
++
++	denied, _ := d.maps()
++	if denied == nil {
++		return
++	}
++	for _, key := range keys {
++		// a pid namespace teardown can take the whole key set with it
++		if err := denied.Delete(key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
++			d.log.Debug("cannot retract excluded pid", "pid", pid, "error", err)
++		}
++	}
++}
++
++// Flush retries denials recorded while the BPF maps were still unavailable.
++// Cheap and a no-op in the common case; the matcher calls it once per batch of
++// process events.
++func (d *DeniedPIDs) Flush() {
++	if d == nil || d.ctx == nil {
++		return
++	}
++
++	d.mu.Lock()
++	defer d.mu.Unlock()
++
++	if d.backlog {
++		d.flushLocked()
++	}
++}
++
++func (d *DeniedPIDs) flushLocked() {
++	denied, cache := d.maps()
++	if denied == nil {
++		d.log.Debug("BPF pid filter not loaded yet, deferring exclusions", "pids", len(d.published))
++		return
++	}
++
++	d.backlog = false
++	for pid, keys := range d.published {
++		for _, key := range keys {
++			if err := denied.Put(key, uint8(1)); err != nil {
++				// A full map is the interesting case: it means new exclusions
++				// stop reaching the kernel, which fails open.
++				d.log.Warn("cannot publish excluded pid to the BPF pid filter",
++					"pid", pid, "nspid", key.Pid, "ns", key.Ns, "error", err)
++				d.backlog = true
++				continue
++			}
++			evictPIDCache(cache, key.Pid)
++		}
++		evictPIDCache(cache, uint32(pid))
++	}
++}
++
++// evictPIDCache drops a memoised valid_pid() pass.
++//
++// pid_cache is a positive cache: valid_pid() writes it only for a pid it just
++// accepted, and returns from it without looking at anything else. An excluded
++// process that made egress before discovery got to it was accepted on its
++// parent's ticket and cached, so publishing the denial without this would
++// change nothing for that process for as long as the entry lives.
++//
++// The map is keyed by a bare u32 with no namespace, and upstream looks it up
++// with the host tgid while storing under the namespaced pid, so both spellings
++// are evicted. A number that collides with an unrelated host pid costs that
++// process one re-evaluation of valid_pid(), which is what BlockPID() has
++// always done too.
++func evictPIDCache(cache *ebpf.Map, pid uint32) {
++	if cache == nil {
++		return
++	}
++	_ = cache.Delete(pid)
++}
++
++// keysFor reads the identities BPF will see for a host pid. Mirrors
++// PIDsFilter.addPID(): the pid namespace inode plus every level of NSpid.
++func (d *DeniedPIDs) keysFor(pid app.PID) []deniedPIDKey {
++	ns, err := procs.FindNamespace(pid)
++	if err != nil {
++		// the process exited between the poll and here; the next poll reports
++		// it deleted and there is nothing left to deny
++		d.log.Debug("cannot read pid namespace of excluded process", "pid", pid, "error", err)
++		return nil
++	}
++
++	nsPIDs, err := procs.FindNamespacedPids(pid)
++	if err != nil {
++		d.log.Debug("cannot read namespaced pids of excluded process", "pid", pid, "error", err)
++		return nil
++	}
++	if len(nsPIDs) == 0 {
++		// no NSpid line in /proc/<pid>/status: not a namespaced kernel, so the
++		// pid BPF derives is this one. The allow side skips such a process
++		// entirely; denying is the safe direction, so it is published instead.
++		nsPIDs = []app.PID{pid}
++	}
++
++	keys := make([]deniedPIDKey, 0, len(nsPIDs))
++	for _, nsPID := range nsPIDs {
++		keys = append(keys, deniedPIDKey{Pid: uint32(nsPID), Ns: ns})
++	}
++
++	return keys
++}
++
++func (d *DeniedPIDs) maps() (denied, cache *ebpf.Map) {
++	d.ctx.MapsLock.Lock()
++	defer d.ctx.MapsLock.Unlock()
++
++	return d.ctx.EBPFMaps[deniedPIDsMapName], d.ctx.EBPFMaps[pidCacheMapName]
++}

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -137,3 +137,114 @@ Currently contains patches:
   bystander's, both at establishment and after the bystander's one request —
   which must also arrive byte-identical and without a Traceparent, while the
   harness's identical request gets one.
+* 013-deny-before-parent-fallback.patch
+  Make discovery's exclusions real in the kernel. `valid_pid()` (bpf/pid/pid.h)
+  looks the calling process up in the allow bitmap and, on a miss, retries with
+  its namespaced parent pid. That fallback is deliberate — it is how OBI follows
+  an instrumented process into its workers, and 012's scenario depends on it
+  staying intact — but userspace only ever *declined to add* an excluded process
+  to the allow-list; nothing ever told BPF what had been excluded. So with
+  `open_ports` discovery, where pid 1 is routinely instrumented and every
+  process on the machine descends from pid 1, `exclude_instrument` meant nothing
+  below the userspace pipeline. Observed live before this patch: an excluded
+  `tailscaled` enrolled 2/2 into the sockhash, because systemd was discovered
+  through open_ports.
+
+  Semantics. A new `denied_pids` hash, keyed exactly like the allow-list
+  (`pid_data_t` = namespaced pid + pid-namespace inode), is consulted in
+  `valid_pid` ahead of both the allow bitmap and the parent fallback. Only the
+  caller's *own* identity is looked up: a denied parent does not taint its
+  children, because a supervisor the user excluded may legitimately fork the
+  workload they asked for, and that workload has its own allow-list entry.
+  Allowed processes and their non-excluded children are unaffected — the
+  fork-following fallback is untouched, and the per-event hot path is unchanged
+  because a `pid_cache` hit still returns before any of this.
+
+  An exact hash rather than a second copy of the bitmap: `valid_pids` hashes
+  (ns, pid) into 192053 bits with no collision resolution, which upstream can
+  afford because a collision there fails *open* and merely lets an extra process
+  through. The same collision in a deny structure fails closed and would
+  silently stop instrumenting a process the user did select.
+
+  Who publishes it. The criteria matcher (`filterCreated` in
+  pkg/appolly/discover/matcher.go) is the only component that evaluates
+  `exclude_instrument`, and the only one that ever sees the processes it drops:
+  an excluded process never becomes an Instrumentable, so it never reaches the
+  attacher and `BlockPID` could not carry this. It publishes when a process
+  matches an exclusion and retracts when the same pid matches the criteria
+  instead; `filterDeleted` retracts on exit, because pids are reused and a
+  denial that outlived its process would silently stop instrumenting the next
+  owner. The keys are every NSpid level of the process under its pid-namespace
+  inode, exactly as `PIDsFilter.addPID()` records the allow side, so the two
+  sides agree whichever level the kernel derives. The map is reached by name
+  through `EBPFEventContext.EBPFMaps` — the agent-wide store of
+  OBI_PIN_INTERNAL maps that `ResolveMaps()` fills — which is one map object
+  shared by every collection that includes pid.h, with a lifetime independent of
+  any single ProcessTracer.
+
+  Each denial also evicts the pid from `pid_cache`, and that is not
+  housekeeping. `pid_cache` is a positive memo of a `valid_pid` pass, consulted
+  before anything else; an excluded process that made egress before discovery
+  reached it was accepted on its parent's ticket and cached, so publishing the
+  denial alone would change nothing for that process for as long as the entry
+  lives. The eviction is what makes the cheap check order safe.
+
+  Residual staleness, all of it fail-open, and none of it removable without
+  matching executables inside BPF:
+  - Discovery lag. The watcher polls every `discovery.poll_interval` (5s by
+    default; its only BPF accelerator is a `sys_bind` kprobe that forces a port
+    refetch) and holds back processes younger than `discovery.min_process_age`
+    (5s), so a just-`exec`ed excluded process still passes on an ancestor's
+    ticket until it is seen. Measured in the harness: 4.3s for a process that
+    predates OBI, 10.1s for one started mid-run.
+  - Pid reuse within one poll interval. If an excluded pid dies and the number
+    is taken by another process before the next poll, the watcher reports
+    neither the exit nor the creation and the denial stands for the new owner.
+    That direction loses instrumentation rather than corrupting bytes, the
+    reverse case (an allowed pid reused by an excluded process) is upstream's
+    existing behaviour, and the retraction on any later match closes it as soon
+    as the pipeline sees the pid again.
+  - A process that exits between the poll and the publish has no
+    `/proc/<pid>/{status,ns/pid}` left to read, so nothing is published — and it
+    generates no more egress either.
+  - A full `denied_pids` (3001 entries, sized like `valid_pids`) refuses new
+    denials and logs a warning. It is a plain hash, not an LRU, so an existing
+    denial can never quietly lapse.
+
+  Kernel floor: the only thing new anywhere is one `bpf_map_lookup_elem` on a
+  `BPF_MAP_TYPE_HASH`. The helper is in the unconditional part of
+  `bpf_base_func_proto()` and the map type is as old as BPF maps, so every
+  program type that already compiles `valid_pid` keeps loading; nothing here is
+  younger than the 5.15 support floor. No new program, no new attachment, no new
+  helper, and the per-program map count is unchanged in kind (one more shared
+  map, far below MAX_USED_MAPS). The programs that consult `valid_pid` are
+  generictracer's kprobes/uprobes and tpinjector's sk_msg entry; the Go uprobes
+  are scoped by being attached per discovered executable and their objects come
+  out byte-identical.
+
+  Verifier cost vs 012: `obi_packet_extender` 851 -> 860, every tail-called
+  sk_msg program unchanged, `obi_sockmap_tracker` and `obi_sk_iter_tcp`
+  unchanged. generictracer's programs move by +8..+82 where `valid_pid` is
+  inlined (its largest, `obi_kprobe_tcp_close`, 29506 -> 29516) and a handful
+  shrink by up to 139 as LLVM re-lays them out; the collection's total falls by
+  58 instructions.
+
+  `ebpf/tests/egress-integrity` grows a `deny-child` scenario, with a control on
+  both sides. The instrumented harness spawns a *direct* child — no reparenting,
+  unlike 012's bystander, so its parent is genuinely allowed — running a copy of
+  the payload at `/tmp/deny-child`, which run-under-obi.sh excludes in the OBI
+  config it composes. The child announces its pid and waits before opening any
+  socket, because `valid_pid` is consulted at `connect()` time in
+  `obi_kprobe_tcp_connect`: it is released only once its exclusion is visible in
+  `denied_pids`, so the scenario waits on an observable rather than a sleep.
+  Then its one HTTP/1.1 request must arrive byte-identical and without a
+  Traceparent, its socket must be absent from `sock_dir` both at establishment
+  and after that request, while the parent's identical request in the same
+  scenario gets a Traceparent and the parent's socket is enrolled — and the
+  parent must not itself be in `denied_pids`. run-under-obi.sh also starts an
+  excluded process *before* OBI, which is the production shape of the bug and
+  the only way to exercise the publisher's deferral, since the first discovery
+  poll runs before any BPF collection exists; its exclusion must reach the map
+  too. Against pristine+008..012 the scenario reports all four differences from
+  one run: the child's socket enrolled in `sock_dir`, one Traceparent on its
+  request, 61 bytes arriving as 131, and the socket still enrolled afterwards.

--- a/ebpf/tests/egress-integrity/deny_child.go
+++ b/ebpf/tests/egress-integrity/deny_child.go
@@ -1,0 +1,451 @@
+package main
+
+// Scenario proving that a discovery exclusion beats the pid filter's parent
+// fallback.
+//
+// valid_pid() (bpf/pid/pid.h) checks the allow-list for the calling process
+// and, on a miss, retries with its parent. That fallback is how OBI follows an
+// instrumented process into its workers, and the sockhash-scoping scenario
+// relies on it being intact. But it also let a process the user *excluded*
+// through on an ancestor's ticket: userspace only ever declined to add such a
+// process to the allow-list, and never told the kernel it was excluded. With
+// `open_ports` discovery pid 1 is routinely instrumented and everything
+// descends from pid 1, so `exclude_instrument` meant nothing in the kernel.
+// Patch 013 publishes the exclusions into `denied_pids` and consults them
+// first.
+//
+// The subject here is therefore a *direct* child of the instrumented harness —
+// no reparenting, unlike the sockhash-scoping bystander — running a copy of
+// this binary at a path the CI config excludes. Its parent is allowed, it is
+// not, and the two must not be confused.
+//
+// The child announces its pid and waits before it opens any socket. That
+// ordering is the point: valid_pid() is consulted in obi_kprobe_tcp_connect at
+// connect() time, so a socket dialled before discovery published the exclusion
+// would have been enrolled into the sockhash for the rest of its life. The
+// harness releases the child only once the exclusion is visible in
+// `denied_pids`, which also makes the scenario wait on an observable rather
+// than on a sleep. Against a build without the map (008..012) it falls back to
+// waiting out the discovery window, and then fails on the assertions, which is
+// what makes it a negative control rather than a tautology.
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// linux/bpf.h
+	bpfMapTypeHash = 1
+
+	deniedPidsMapName = "denied_pids"
+
+	// A path the harness's own discovery criterion (*egress-integrity*) does
+	// not match and run-under-obi.sh excludes explicitly.
+	denyChildExe = "/tmp/deny-child"
+
+	// Written by run-under-obi.sh for the process it starts before OBI, at a
+	// path the same exclusion matches.
+	denyChildEarlyPIDFile = "/tmp/deny-child-early.pid"
+
+	denyChildRequest  = "GET /deny-child HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"
+	denyParentRequest = "GET /deny-parent HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n"
+
+	// Discovery has to notice the child first: the watcher polls every
+	// discovery.poll_interval (5s by default) and skips processes younger than
+	// discovery.min_process_age (5s), so ~10s is expected. The cap is the
+	// margin over that, kept under the harness watchdog.
+	denyPublishTimeout = 45 * time.Second
+	denyPublishPoll    = 250 * time.Millisecond
+
+	// Used only when `denied_pids` does not exist, i.e. against a pre-013 OBI:
+	// long enough that the child is certainly discovered and excluded in
+	// userspace, so the failure that follows is about the kernel honouring it.
+	denyPublishWindow = 25 * time.Second
+)
+
+// denyChild is the excluded subject: a copy of this binary at an excluded path,
+// started as a plain child of the instrumented harness and left there.
+func denyChild(port int) error {
+	// Announced before any socket exists, so the harness can wait for the
+	// exclusion to reach BPF before this process dials.
+	if _, err := fmt.Printf("ready pid %d\n", os.Getpid()); err != nil {
+		return err
+	}
+	if err := awaitDenyGate(); err != nil {
+		return fmt.Errorf("waiting to dial: %w", err)
+	}
+
+	conn, err := rawDial(port)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	cookie, err := socketCookie(conn.fd)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Printf("cookie %d\n", cookie); err != nil {
+		return err
+	}
+	if err := awaitDenyGate(); err != nil {
+		return fmt.Errorf("waiting to send: %w", err)
+	}
+
+	if err := writeAll(conn, []byte(denyChildRequest)); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if line != "HTTP/1.1 204 No Content\r\n" {
+		return fmt.Errorf("bad server status line %q", line)
+	}
+	if err := readHeader(reader); err != nil {
+		return err
+	}
+	if _, err := fmt.Println("sent"); err != nil {
+		return err
+	}
+
+	// Hold the socket open so the harness can sample sock_dir again; it closes
+	// our stdin when it is done.
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	return nil
+}
+
+func awaitDenyGate() error {
+	gate := make([]byte, 1)
+	_, err := io.ReadFull(os.Stdin, gate)
+	return err
+}
+
+// denyKeyFor builds the denied_pids key OBI publishes for a pid: pid_data_t
+// {u32 nspid; u32 ns}, which on the little-endian architectures OBI supports
+// is the namespaced pid in the low half of the 8-byte key and the pid
+// namespace inode in the high half.
+//
+// The harness shares this container's pid namespace with OBI and with the
+// child, so the pid it knows is the namespaced one, and /proc/<pid>/ns/pid is
+// the same link OBI reads (procs.FindNamespace). Comparing the whole key keeps
+// the check exact: a match cannot be some other denied process's entry.
+func denyKeyFor(pid int) (uint64, error) {
+	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", pid))
+	if err != nil {
+		return 0, err
+	}
+	openIdx, closeIdx := strings.LastIndex(link, "["), strings.LastIndex(link, "]")
+	if openIdx < 0 || closeIdx < openIdx {
+		return 0, fmt.Errorf("unexpected pid namespace link %q", link)
+	}
+	ns, err := strconv.ParseUint(link[openIdx+1:closeIdx], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("unexpected pid namespace link %q: %w", link, err)
+	}
+
+	return uint64(ns)<<32 | uint64(uint32(pid)), nil
+}
+
+// deniedPIDs reports the published exclusions, and whether the map exists at
+// all: it does not on an OBI built without patch 013.
+func deniedPIDs() (keys map[uint64]struct{}, haveMap bool, err error) {
+	return bpfMapKeys(deniedPidsMapName, bpfMapTypeHash)
+}
+
+// waitForDenial blocks until pid's exclusion is in denied_pids, reporting how
+// long that took and how many entries the map holds, because "it was already
+// there" and "it arrived" are different facts and only the run can tell them
+// apart.
+func waitForDenial(pid int) (haveMap bool, err error) {
+	want, err := denyKeyFor(pid)
+	if err != nil {
+		return false, err
+	}
+
+	start := time.Now()
+	for {
+		keys, haveMap, err := deniedPIDs()
+		if err != nil {
+			return false, fmt.Errorf("reading %s: %w", deniedPidsMapName, err)
+		}
+		if !haveMap {
+			return false, nil
+		}
+		if _, ok := keys[want]; ok {
+			fmt.Printf("deny-child: exclusion for pid %d published after %s (%d entries in %s)\n",
+				pid, time.Since(start).Round(10*time.Millisecond), len(keys), deniedPidsMapName)
+			return true, nil
+		}
+		if time.Since(start) > denyPublishTimeout {
+			return true, fmt.Errorf("OBI did not exclude pid %d within %s (%d entries in %s)",
+				pid, denyPublishTimeout, len(keys), deniedPidsMapName)
+		}
+		time.Sleep(denyPublishPoll)
+	}
+}
+
+// requireEarlyDenial checks the exclusion of the process run-under-obi.sh
+// starts before OBI. Its denial is recorded during the first discovery poll,
+// which runs before any BPF collection exists, so it is the one that has to
+// survive being published later — and it is the shape the bug had in
+// production: an excluded daemon already running when the agent starts.
+func requireEarlyDenial() error {
+	raw, err := os.ReadFile(denyChildEarlyPIDFile)
+	if errors.Is(err, os.ErrNotExist) {
+		// payload run without the runner
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return fmt.Errorf("bad %s: %w", denyChildEarlyPIDFile, err)
+	}
+
+	haveMap, err := waitForDenial(pid)
+	if err != nil {
+		return fmt.Errorf("process started before OBI: %w", err)
+	}
+	if !haveMap {
+		fmt.Printf("deny-child: no %s map; skipping the pre-OBI exclusion check\n", deniedPidsMapName)
+	}
+
+	return nil
+}
+
+//nolint:gocyclo
+func denyChildScenario(selfcheck bool) error {
+	// SO_COOKIE and the BPF maps only exist on Linux; local darwin selfcheck
+	// runs the other scenarios and CI's Linux selfcheck covers this one.
+	if runtime.GOOS != "linux" {
+		fmt.Println("deny-child: skipped (Linux-only)")
+		return nil
+	}
+
+	ln, err := rawListen()
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	// --- allowed control: this process is the child's parent, and allowed ----
+	allowed, err := rawDial(ln.port)
+	if err != nil {
+		return err
+	}
+	defer allowed.Close()
+	allowedCookie, err := socketCookie(allowed.fd)
+	if err != nil {
+		return err
+	}
+	allowedServer, err := ln.accept()
+	if err != nil {
+		return err
+	}
+	defer allowedServer.Close()
+
+	allowedRecorder := &recordingConn{rawConn: allowedServer}
+	if err := writeAll(allowed, []byte(denyParentRequest)); err != nil {
+		return fmt.Errorf("parent client write: %w", err)
+	}
+	parentTPs, err := readRequest(bufio.NewReader(allowedRecorder), allowedRecorder)
+	if err != nil {
+		return fmt.Errorf("parent server read: %w", err)
+	}
+	allowedReader := bufio.NewReader(allowed)
+	if _, err := allowedReader.ReadString('\n'); err != nil {
+		return err
+	}
+	if err := readHeader(allowedReader); err != nil {
+		return err
+	}
+
+	wantParentTPs := 1
+	if selfcheck {
+		wantParentTPs = 0
+	}
+	if parentTPs != wantParentTPs {
+		return fmt.Errorf("parent process: %d Traceparents on its request, want %d", parentTPs, wantParentTPs)
+	}
+
+	// --- an excluded process that predates OBI ------------------------------
+	if !selfcheck {
+		if err := requireEarlyDenial(); err != nil {
+			return err
+		}
+	}
+
+	// --- the excluded direct child ------------------------------------------
+	if err := copySelfTo(denyChildExe); err != nil {
+		return fmt.Errorf("staging deny-child: %w", err)
+	}
+	defer os.Remove(denyChildExe)
+
+	gateR, gateW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer gateW.Close()
+	reportR, reportW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer reportR.Close()
+
+	// Started and deliberately not waited for: this process has to remain its
+	// parent, because an allowed parent is exactly what the scenario is about.
+	child := exec.Command(denyChildExe, "-deny-child", strconv.Itoa(ln.port))
+	child.Stdin = gateR
+	child.Stdout = reportW
+	child.Stderr = os.Stderr
+	err = child.Start()
+	_ = gateR.Close()
+	_ = reportW.Close()
+	if err != nil {
+		return fmt.Errorf("starting deny-child: %w", err)
+	}
+	defer func() {
+		_ = child.Process.Kill()
+		_ = child.Wait()
+	}()
+
+	childOut := bufio.NewReader(reportR)
+	line, err := childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading deny-child readiness: %w", err)
+	}
+	childPID := 0
+	if _, err := fmt.Sscanf(line, "ready pid %d", &childPID); err != nil {
+		return fmt.Errorf("bad deny-child readiness line %q: %w", line, err)
+	}
+	if childPID != child.Process.Pid {
+		return fmt.Errorf("deny-child reported pid %d, started %d", childPID, child.Process.Pid)
+	}
+
+	// --- wait for the exclusion to reach the kernel -------------------------
+	haveDenyMap := false
+	if !selfcheck {
+		haveDenyMap, err = waitForDenial(childPID)
+		if err != nil {
+			return err
+		}
+		if !haveDenyMap {
+			// No denied_pids map: an OBI without patch 013. Give discovery the
+			// same chance to see the child, then let the assertions below say
+			// what that build does with it.
+			fmt.Printf("deny-child: no %s map; waiting out the discovery window (%s)\n",
+				deniedPidsMapName, denyPublishWindow)
+			time.Sleep(denyPublishWindow)
+		}
+	}
+
+	// --- release the dial ---------------------------------------------------
+	if _, err := gateW.Write([]byte("g")); err != nil {
+		return err
+	}
+	line, err = childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("reading deny-child cookie: %w", err)
+	}
+	var childCookie uint64
+	if _, err := fmt.Sscanf(line, "cookie %d", &childCookie); err != nil {
+		return fmt.Errorf("bad deny-child cookie line %q: %w", line, err)
+	}
+	if childCookie == allowedCookie {
+		return errors.New("socket cookies collided; the membership check would be meaningless")
+	}
+
+	childServer, err := ln.accept()
+	if err != nil {
+		return err
+	}
+	defer childServer.Close()
+	childRecorder := &recordingConn{rawConn: childServer}
+
+	// Failures from here on are collected rather than returned one at a time.
+	// Against an OBI that does not honour the exclusion every consequence is
+	// worth seeing from a single run: the socket enrolled into the sockhash,
+	// the Traceparent spliced in, and the bytes that changed because of it.
+	var problems []error
+
+	// --- at establishment: the parent's socket is enrolled, the child's is not
+	before, haveSockDir, err := sockDirCookies()
+	if err != nil {
+		return fmt.Errorf("reading sock_dir: %w", err)
+	}
+	if !haveSockDir && !selfcheck {
+		return errors.New("no sock_dir SOCKHASH found; tpinjector is not enrolling anything")
+	}
+	if haveSockDir {
+		problems = append(problems,
+			requireMembership("at establishment", before, allowedCookie, true),
+			requireMembership("at establishment", before, childCookie, false))
+	}
+
+	// --- release the child's one request ------------------------------------
+	if _, err := gateW.Write([]byte("g")); err != nil {
+		return err
+	}
+	childTPs, err := readRequest(bufio.NewReader(childRecorder), childRecorder)
+	if err != nil {
+		return fmt.Errorf("deny-child server read: %w", err)
+	}
+	if childTPs != 0 {
+		problems = append(problems, fmt.Errorf(
+			"excluded child's request carried %d Traceparents on its allowed parent's ticket", childTPs))
+	}
+	if err := byteDiff([]byte(denyChildRequest), childRecorder.read.Bytes()); err != nil {
+		problems = append(problems, fmt.Errorf("excluded child's request mutated: %w", err))
+	}
+
+	done, err := childOut.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("waiting for deny-child: %w", err)
+	}
+	if done != "sent\n" {
+		return fmt.Errorf("unexpected deny-child output %q", done)
+	}
+
+	// --- after egress: still only the parent's socket -----------------------
+	if haveSockDir {
+		after, _, err := sockDirCookies()
+		if err != nil {
+			return fmt.Errorf("re-reading sock_dir: %w", err)
+		}
+		problems = append(problems,
+			requireMembership("after child egress", after, childCookie, false),
+			requireMembership("after child egress", after, allowedCookie, true))
+	}
+
+	// Proven, not assumed: the child was denied by name, and its parent stayed
+	// allowed throughout. Without the second half the scenario would also pass
+	// on a build that simply stopped instrumenting anything.
+	if haveDenyMap {
+		keys, _, err := deniedPIDs()
+		if err != nil {
+			return err
+		}
+		self, err := denyKeyFor(os.Getpid())
+		if err != nil {
+			return err
+		}
+		if _, denied := keys[self]; denied {
+			problems = append(problems, fmt.Errorf(
+				"the instrumented parent (pid %d) is in %s", os.Getpid(), deniedPidsMapName))
+		}
+	}
+
+	return errors.Join(problems...)
+}

--- a/ebpf/tests/egress-integrity/main.go
+++ b/ebpf/tests/egress-integrity/main.go
@@ -560,6 +560,7 @@ func main() {
 	startFile := flag.String("start-file", "", "wait for this file before opening sockets")
 	bystanderPort := flag.Int("bystander", 0, "internal: run as the non-discovered client of sockhash-scoping")
 	bystanderSpawner := flag.Int("bystander-spawner", 0, "internal: pid of the process that reparented us")
+	denyChildPort := flag.Int("deny-child", 0, "internal: run as the excluded direct child of deny-child")
 	flag.Parse()
 
 	// The sockhash-scoping scenario re-executes this binary from a path OBI's
@@ -573,6 +574,16 @@ func main() {
 		}
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "bystander:", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// The deny-child scenario spawns this binary from an excluded path as a
+	// plain child of the instrumented harness; that copy takes this branch.
+	if *denyChildPort != 0 {
+		if err := denyChild(*denyChildPort); err != nil {
+			fmt.Fprintln(os.Stderr, "deny-child:", err)
 			os.Exit(1)
 		}
 		return
@@ -599,6 +610,7 @@ func main() {
 		{"raw-binary", rawBinary},
 		{"positive-control", func() error { return positiveControl(*selfcheck) }},
 		{"sockhash-scoping", func() error { return sockhashScoping(*selfcheck) }},
+		{"deny-child", func() error { return denyChildScenario(*selfcheck) }},
 	}
 	for _, scenario := range scenarios {
 		progressScenario.Store(scenario.name)

--- a/ebpf/tests/egress-integrity/run-under-obi.sh
+++ b/ebpf/tests/egress-integrity/run-under-obi.sh
@@ -9,12 +9,14 @@ payload_log=/tmp/egress-integrity.log
 start_file=/tmp/egress-integrity.start
 obi_pid=
 payload_pid=
+early_pid=
 
 cleanup() {
   status=$?
   set +e
   [ -n "$payload_pid" ] && kill "$payload_pid" 2>/dev/null
   [ -n "$obi_pid" ] && kill "$obi_pid" 2>/dev/null
+  [ -n "$early_pid" ] && kill -9 "$early_pid" 2>/dev/null
   sleep 1
   [ -n "$payload_pid" ] && kill -9 "$payload_pid" 2>/dev/null
   [ -n "$obi_pid" ] && kill -9 "$obi_pid" 2>/dev/null
@@ -47,6 +49,36 @@ fi
 if ! grep -q ' /sys/kernel/tracing tracefs ' /proc/mounts; then
   mount -t tracefs tracefs /sys/kernel/tracing
 fi
+
+# The deny-child scenario needs '*deny-child*' excluded from instrumentation,
+# and it is the runner's job rather than each caller's: the scenario is part of
+# this harness, so its precondition travels with it. Inserted right after the
+# top-level discovery key, at the same indentation as the instrument list the
+# callers set; the grep fails the run loudly if the config had no such block.
+run_config=/tmp/obi-config-with-exclusion.yml
+awk '{ print }
+     /^discovery:[[:space:]]*$/ {
+       print "  exclude_instrument:"
+       print "    - exe_path: \"*deny-child*\""
+     }' "$config" >"$run_config"
+grep -q 'deny-child' "$run_config"
+config=$run_config
+
+# An excluded process that predates OBI. This is the production shape of the
+# bug in T-20708 — an excluded daemon already running when the agent starts —
+# and the only way to exercise the publisher's deferral, because the first
+# discovery poll runs before the first BPF collection exists, so the exclusion
+# is recorded before there is a map to put it in. Any executable will do; only
+# its path has to match the exclusion.
+early_exe=/tmp/deny-child-early
+early_pid_file=/tmp/deny-child-early.pid
+rm -f "$early_pid_file"
+cp /usr/bin/sleep "$early_exe"
+"$early_exe" 600 &
+early_pid=$!
+echo "$early_pid" >"$early_pid_file"
+# keeps bash from printing a job notification when cleanup kills it
+disown "$early_pid"
 
 rm -f "$start_file"
 "$obi" -config "$config" >"$obi_log" 2>&1 &

--- a/ebpf/tests/egress-integrity/sockhash_scoping.go
+++ b/ebpf/tests/egress-integrity/sockhash_scoping.go
@@ -106,12 +106,12 @@ type bpfAttrElem struct {
 	flags   uint64
 }
 
-// sockDirFDs returns a file descriptor for every SOCKHASH named sock_dir that
+// bpfMapFDs returns a file descriptor for every map of this name and type that
 // this process can see. Walking the id space rather than a bpffs pin keeps the
 // harness independent of OBI's pinning configuration, and it is what
 // `bpftool map dump name sock_dir` does — bpftool is not installable in the
 // --network=none container the scenarios run in.
-func sockDirFDs() ([]int, error) {
+func bpfMapFDs(name string, mapType uint32) ([]int, error) {
 	var fds []int
 	id := uint32(0)
 	for {
@@ -151,8 +151,8 @@ func sockDirFDs() ([]int, error) {
 			continue
 		}
 
-		name := string(bytes.TrimRight(info[mapInfoNameAt:mapInfoNameAt+mapInfoNameLen], "\x00"))
-		if name != sockDirMapName || binary.NativeEndian.Uint32(info[0:4]) != bpfMapTypeSockash {
+		got := string(bytes.TrimRight(info[mapInfoNameAt:mapInfoNameAt+mapInfoNameLen], "\x00"))
+		if got != name || binary.NativeEndian.Uint32(info[0:4]) != mapType {
 			_ = syscall.Close(fd)
 			continue
 		}
@@ -160,11 +160,12 @@ func sockDirFDs() ([]int, error) {
 	}
 }
 
-// sockDirCookies returns the set of socket cookies currently enrolled in
-// sock_dir, or ok=false when no such map exists (selfcheck runs, where OBI
-// never loaded).
-func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
-	fds, err := sockDirFDs()
+// bpfMapKeys returns the key set of every map of this name and type, or
+// ok=false when no such map exists (selfcheck runs, where OBI never loaded).
+// Both maps this harness reads have 8-byte keys: sock_dir is keyed by socket
+// cookie, denied_pids by pid_data_t (namespaced pid in the low half).
+func bpfMapKeys(name string, mapType uint32) (keys map[uint64]struct{}, ok bool, err error) {
+	fds, err := bpfMapFDs(name, mapType)
 	if err != nil {
 		return nil, false, err
 	}
@@ -177,12 +178,12 @@ func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
 		}
 	}()
 
-	cookies = map[uint64]struct{}{}
+	keys = map[uint64]struct{}{}
 	for _, fd := range fds {
 		var key, next uint64
 		haveKey := false
-		// sock_dir holds at most 65535 entries; the bound only guards against a
-		// map being mutated underneath the walk.
+		// sock_dir holds at most 65535 entries and denied_pids 3001; the bound
+		// only guards against a map being mutated underneath the walk.
 		for range 1 << 17 {
 			attr := bpfAttrElem{
 				mapFD:   uint32(fd),
@@ -200,12 +201,18 @@ func sockDirCookies() (cookies map[uint64]struct{}, ok bool, err error) {
 			if errno != 0 {
 				return nil, false, fmt.Errorf("BPF_MAP_GET_NEXT_KEY: %w", errno)
 			}
-			cookies[next] = struct{}{}
+			keys[next] = struct{}{}
 			key = next
 			haveKey = true
 		}
 	}
-	return cookies, true, nil
+	return keys, true, nil
+}
+
+// sockDirCookies returns the set of socket cookies currently enrolled in
+// sock_dir.
+func sockDirCookies() (map[uint64]struct{}, bool, error) {
+	return bpfMapKeys(sockDirMapName, bpfMapTypeSockash)
 }
 
 // respawnBystander re-executes the bystander with its pipes and exits, so the


### PR DESCRIPTION
Stacked on #154. Patch 013: `exclude_instrument` currently only prevents allow-list additions — `valid_pid()`'s parent fallback passes any excluded process whose ancestor is allowed (observed live: instrumented pid 1 made every process on the host eligible, including an explicitly excluded one, whose sockets kept enrolling into the tpinjector sockhash).

- New exact-match `denied_pids` map (same key space as the allow bitmap; exact because a deny-side collision would fail closed), consulted for the own pid before the allow check and the parent fallback; parent chain never consulted for deny, so fork-following of selected workloads is preserved.
- Published from the single exclusion evaluator (`discover/matcher.go`), with `pid_cache` positive-memo eviction and a backlog/flush path for denials that precede the first BPF collection.
- Documented residual: the /proc poll interval leaves a small window for freshly exec'd excluded processes.
- Harness: new `deny-child` scenario (direct child of the instrumented process at an excluded exe path → zero injection, absent from sock_dir, parent unaffected); fails four distinct ways against a pre-013 build, including a hex dump of the Traceparent spliced into the excluded child's stream.

Verifier budget: `obi_packet_extender` 851→860; generictracer programs ±≤139 where `valid_pid` inlines; gotracer byte-identical. All programs load; full harness green; CI on the 5.15 runner is the final arbiter.

Kept off the #154 branch deliberately so the deployed `pr-154` image tag stays frozen during the overnight soak.