### PR TITLE
eBPF: stop OBI cloning the process environment per span

### DIFF
--- a/.github/workflows/obi-patch-ci.yml
+++ b/.github/workflows/obi-patch-ci.yml
@@ -68,9 +68,9 @@ jobs:
         working-directory: ${{ runner.temp }}/obi
         run: go mod download
 
-      - name: Test tpinjector package
+      - name: Test patched packages
         working-directory: ${{ runner.temp }}/obi
-        run: go test -race ./pkg/internal/ebpf/tpinjector
+        run: go test -race ./pkg/internal/ebpf/tpinjector ./pkg/appolly/discover/exec ./pkg/internal/procs
 
       - name: Build production OBI stage
         run: docker build --target obi-builder --file ebpf/Dockerfile .

--- a/ebpf/patches/obi/014-no-per-span-env-clone.patch
+++ b/ebpf/patches/obi/014-no-per-span-env-clone.patch
@@ -1,0 +1,61 @@
+diff --git a/pkg/appolly/discover/exec/file.go b/pkg/appolly/discover/exec/file.go
+index eabf55c5d..3cf8099ea 100644
+--- a/pkg/appolly/discover/exec/file.go
++++ b/pkg/appolly/discover/exec/file.go
+@@ -104,8 +104,13 @@ func (fi *FileInfo) ServiceAttrs() svc.Attrs {
+ 	defer fi.mu.RUnlock()
+ 
+ 	out := fi.service
++	// Metadata is decorated per span downstream, so every span needs its own
++	// copy. EnvVars is only ever read after discovery (ApplyEnvVariables
++	// replaces the whole map under the lock), so spans share the one map: a
++	// per-span clone is paid on every event and, for a process whose environ
++	// region was overwritten by setproctitle (nginx, valkey, ruby, sshd), the
++	// map is sized for thousands of empty NUL-separated entries.
+ 	out.Metadata = maps.Clone(fi.service.Metadata)
+-	out.EnvVars = maps.Clone(fi.service.EnvVars)
+ 
+ 	// no need to clone the other fields as they are immutable
+ 	return out
+diff --git a/pkg/appolly/discover/exec/file_test.go b/pkg/appolly/discover/exec/file_test.go
+index dbc946a94..da19673c8 100644
+--- a/pkg/appolly/discover/exec/file_test.go
++++ b/pkg/appolly/discover/exec/file_test.go
+@@ -102,3 +102,20 @@ func TestApplyEnvVariables(t *testing.T) {
+ 		})
+ 	}
+ }
++
++// ServiceAttrs is called once per span: Metadata is decorated per span so it
++// must be a copy, EnvVars is read-only after discovery so it must be shared.
++func TestServiceAttrsSharesEnvVarsClonesMetadata(t *testing.T) {
++	fi := New(Init{})
++	fi.SetMetadata(map[attr.Name]string{"k": "v"})
++	fi.ApplyEnvVariables(map[string]string{"OTEL_SERVICE_NAME": "svc"})
++
++	snap := fi.ServiceAttrs()
++	snap.Metadata["k"] = "changed"
++	if got := fi.ServiceAttrs().Metadata["k"]; got != "v" {
++		t.Fatalf("Metadata not cloned per snapshot: %q", got)
++	}
++	if reflect.ValueOf(snap.EnvVars).Pointer() != reflect.ValueOf(fi.ServiceAttrs().EnvVars).Pointer() {
++		t.Fatal("EnvVars cloned per snapshot")
++	}
++}
+diff --git a/pkg/internal/procs/procenv.go b/pkg/internal/procs/procenv.go
+index 7d967b881..067a67d7b 100644
+--- a/pkg/internal/procs/procenv.go
++++ b/pkg/internal/procs/procenv.go
+@@ -12,7 +12,11 @@ import (
+ )
+ 
+ func envStrsToMap(varsStr []string) map[string]string {
+-	vars := make(map[string]string, len(varsStr))
++	// not presized from len(varsStr): /proc/<pid>/environ of a process that
++	// rewrote its argv/environ area (setproctitle) splits into thousands of
++	// empty strings, and the hint would reserve hundreds of KiB for a map that
++	// ends up holding a handful of entries
++	vars := map[string]string{}
+ 
+ 	for _, s := range varsStr {
+ 		keyVal := strings.SplitN(s, "=", 2)

--- a/ebpf/patches/obi/README.md
+++ b/ebpf/patches/obi/README.md
@@ -248,3 +248,26 @@ Currently contains patches:
   too. Against pristine+008..012 the scenario reports all four differences from
   one run: the child's socket enrolled in `sock_dir`, one Traceparent on its
   request, 61 bytes arriving as 131, and the socket still enrolled afterwards.
+* 014-no-per-span-env-clone.patch
+  Stop `FileInfo.ServiceAttrs()` cloning the process environment for every
+  span, and stop `procs.envStrsToMap()` presizing that map from the raw
+  NUL-split count of `/proc/<pid>/environ`. Upstream's `PIDsFilter.Filter`
+  calls `ServiceAttrs()` once per span, so each span carried a fresh copy of
+  `EnvVars` and `Metadata`. `EnvVars` is only read after discovery
+  (`ApplyEnvVariables` swaps the whole map under the lock), so spans now share
+  it; `Metadata` stays cloned because the k8s decorator writes it per span.
+
+  Why it mattered: a process that rewrites its argv/environ area with
+  `setproctitle` (valkey, nginx, ruby/puma, sshd) reads back as thousands of
+  empty NUL-separated strings, so the presized map reserved ~8 Swiss tables of
+  40 KiB for a handful of entries, and `maps.Clone` reproduces that layout per
+  span: ~320 KiB per span of those services. Two upstream stages then hold
+  span copies for minutes: `SettleConditionalParents` (new in v0.12.0, #3001)
+  parks up to 8192 `ParentConditional` spans for `max_transaction_time` (5m),
+  and every OTel metrics reporter keeps a `*svc.Attrs` pointing into a
+  100-span batch for its lifetime. Under otel-demo browser load that is
+  1.3 GiB of live env-map copies within five minutes and a 2 GiB cgroup OOM
+  loop; a `viewcore` pass over a core of the unpatched process attributed 75%
+  of the retained 40 KiB map tables to the settler and 20% to
+  `Metrics.service`. Measured on the same k3s node and workload: unpatched
+  reached 750-1450 MiB anon RSS in 5 minutes, patched sits at ~80 MiB.


### PR DESCRIPTION
## Problem

OBI v0.12.x grows to the 2 GiB cgroup limit within ~5 minutes under otel-demo browser load and gets OOM-killed in a loop.

A core dump of the unpatched process (`viewcore`) shows the live heap is almost entirely `map[string]string` clones made by `FileInfo.ServiceAttrs()`, which `PIDsFilter.Filter` calls **once per span**. Two upstream stages keep those span copies alive for minutes:

- `SettleConditionalParents` (new in OBI v0.12.0, open-telemetry/opentelemetry-ebpf-instrumentation#3001) parks up to 8192 `ParentConditional` spans for `max_transaction_time` (5m) - 75% of the retained maps.
- every OTel metrics reporter keeps `Metrics.service *svc.Attrs` pointing into a 100-span batch for its lifetime - 20%.

The clones are large because `procs.envStrsToMap()` presizes the map from the raw NUL-split count of `/proc/<pid>/environ`. A process that rewrote its environ area with `setproctitle` (valkey, nginx, ruby, sshd) reads back as thousands of empty strings, so the map reserves ~8 Swiss tables of 40 KiB for a handful of entries, and `maps.Clone` reproduces that layout on every span: ~320 KiB per span of those services.

## Change

Patch 014:
- `ServiceAttrs()` shares `EnvVars` (read-only after discovery; `ApplyEnvVariables` swaps the whole map under the lock) and keeps cloning `Metadata` (the k8s decorator writes it per span).
- `envStrsToMap()` no longer presizes from `len(varsStr)`.
- One unit test pinning the share/clone split.

CI now also runs `go test -race` for the two patched packages.

## Verification

Same k3s node, same workload (otel-demo with Locust browser traffic, ~40 chrome processes, OBI instrumenting ~45 processes), `GOMEMLIMIT=800MiB`, 2 GiB cgroup:

| | anon RSS after 5 min |
|---|---|
| v0.12.2 + 008..013 (two runs) | 750 MiB and 1450 MiB (OOM-killed at 5m20s) |
| + 014 | 80 MiB, flat |

Heap profile before the patch: `maps.clone` 1322 MiB of 1330 MiB in use. `go test -race ./pkg/appolly/discover/exec ./pkg/internal/procs` passes on the patched tree.
